### PR TITLE
Fix empty line when "lines" have a trailing ";" separator

### DIFF
--- a/src/models/RendererModel.php
+++ b/src/models/RendererModel.php
@@ -82,7 +82,8 @@ class RendererModel
         if (!$lines) {
             throw new InvalidArgumentException("Lines parameter must be set.");
         }
-        $exploded = explode(";", $lines);
+        $trimmed_lines = rtrim($lines, ';');
+        $exploded = explode(";", $trimmed_lines);
         // escape special characters to prevent code injection
         return array_map("htmlspecialchars", $exploded);
     }

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -101,4 +101,25 @@ final class RendererTest extends TestCase
         $expected = str_replace('"monospace"', '"Not-A-Font"', file_get_contents("tests/svg/test_normal.svg"));
         $this->assertEquals($expected, $controller->render());
     }
+    
+    /**
+     * Test if a trailing ";" in lines is trimmed; see issue #25
+     */
+    public function testLineTrimming(): void
+    {
+        $params = array(
+            "lines" => implode(";", array(
+                "Full-stack web and app developer",
+                "Self-taught UI/UX Designer",
+                "10+ years of coding experience",
+                "Always learning new things",
+                "",
+            )),
+            "center" => "true",
+            "width" => "380",
+            "height" => "50",
+        );
+        $controller = new RendererController($params, self::$database);
+        $this->assertEquals(file_get_contents("tests/svg/test_normal.svg"), $controller->render());
+    }
 }


### PR DESCRIPTION
## Description

This PR trims trailing ";" separators from the `lines` query param before separating them into a list.
This prevents an empty line to be animated.

Fixes #25 

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other pull requests are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
