### PR TITLE
Control vertical text alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Feel free to [open a PR](https://github.com/DenverCoder1/readme-typing-svg/issue
 | :---------: | :----------------------------------------------------------------------:      | :-----: | :---------------------------------: |
 |   `lines`   |      Text to display with lines separated by `;` and `+` for spaces           | string  | `First+line;Second+line;Third+line` |
 |  `center`   |   `true` to center text or `false` for left aligned (default: `false`)        | boolean |          `true` or `false`          |
-|  `vCenter`  |`true` to center text vertically or `false` for top aligned (default: `false`) | boolean |          `true` or `false`          |
+|  `vCenter`  | `true` to center vertically or `false`(default) to align above the center     | boolean |          `true` or `false`          |
 |  `height`   |            Height of the output SVG in pixels (default: `50`)                 | integer |         Any positive number         |
 |   `width`   |            Width of the output SVG in pixels (default: `400`)                 | integer |         Any positive number         |
 |   `font`    |                    Font family (default: `monospace`)                         | string  |     Any font from Google Fonts      |

--- a/README.md
+++ b/README.md
@@ -60,16 +60,17 @@ Feel free to [open a PR](https://github.com/DenverCoder1/readme-typing-svg/issue
 
 ## 🔧 Options
 
-|  Parameter  |                                 Details                                  |  Type   |               Example               |
-| :---------: | :----------------------------------------------------------------------: | :-----: | :---------------------------------: |
-|   `lines`   |      Text to display with lines separated by `;` and `+` for spaces      | string  | `First+line;Second+line;Third+line` |
-|  `center`   |   `true` to center text or `false` for left aligned (default: `false`)   | boolean |          `true` or `false`          |
-|  `height`   |            Height of the output SVG in pixels (default: `50`)            | integer |         Any positive number         |
-|   `width`   |            Width of the output SVG in pixels (default: `400`)            | integer |         Any positive number         |
-|   `font`    |                    Font family (default: `monospace`)                    | string  |     Any font from Google Fonts      |
-|   `size`    |                   Font size in pixels (default: `20`)                    | integer |         Any positive number         |
-|   `color`   |                  Color of the text (default: `36BCF7`)                   | string  |  Hex code without # (eg. `00ff00`)  |
-| `multiline` | `true` to wrap lines or `false` to retype on one line (default: `false`) | boolean |          `true` or `false`          |
+|  Parameter  |                                 Details                                       |  Type   |               Example               |
+| :---------: | :----------------------------------------------------------------------:      | :-----: | :---------------------------------: |
+|   `lines`   |      Text to display with lines separated by `;` and `+` for spaces           | string  | `First+line;Second+line;Third+line` |
+|  `center`   |   `true` to center text or `false` for left aligned (default: `false`)        | boolean |          `true` or `false`          |
+|  `vCenter`  |`true` to center text vertically or `false` for top aligned (default: `false`) | boolean |          `true` or `false`          |
+|  `height`   |            Height of the output SVG in pixels (default: `50`)                 | integer |         Any positive number         |
+|   `width`   |            Width of the output SVG in pixels (default: `400`)                 | integer |         Any positive number         |
+|   `font`    |                    Font family (default: `monospace`)                         | string  |     Any font from Google Fonts      |
+|   `size`    |                   Font size in pixels (default: `20`)                         | integer |         Any positive number         |
+|   `color`   |                  Color of the text (default: `36BCF7`)                        | string  |  Hex code without # (eg. `00ff00`)  |
+| `multiline` | `true` to wrap lines or `false` to retype on one line (default: `false`)      | boolean |          `true` or `false`          |
 
 ## 📤 Deploying it on your own
 

--- a/src/demo/css/style.css
+++ b/src/demo/css/style.css
@@ -164,6 +164,7 @@ h2 {
   font-family: inherit;
   background: var(--card-background);
   width: 100%;
+  min-width: 70px;
   color: inherit;
 }
 

--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -71,7 +71,7 @@
                     <option>true</option>
                 </select>
                 
-                <label for="center">Vertically Centered</label>
+                <label for="vCenter">Vertically Centered</label>
                 <select class="param" id="vCenter" name="vCenter" value="false">
                     <option>false</option>
                     <option>true</option>

--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -65,8 +65,14 @@
                 <label for="size">Font size</label>
                 <input class="param" type="number" id="size" name="size" placeholder="20" value="20">
 
-                <label for="center">Centered</label>
+                <label for="center">Horizontally Centered</label>
                 <select class="param" id="center" name="center" value="false">
+                    <option>false</option>
+                    <option>true</option>
+                </select>
+                
+                <label for="center">Vertically Centered</label>
+                <select class="param" id="vCenter" name="vCenter" value="false">
                     <option>false</option>
                     <option>true</option>
                 </select>

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -5,6 +5,7 @@ let preview = {
     color: "36BCF7",
     size: "20",
     center: "false",
+    vCenter: "false",
     multiline: "false",
     width: "400",
     height: "50"

--- a/src/models/RendererModel.php
+++ b/src/models/RendererModel.php
@@ -17,8 +17,11 @@ class RendererModel
     /** @var int $size Font size */
     public $size;
 
-    /** @var bool $center Whether or not to center text */
+    /** @var bool $center Whether or not to center text horizontally */
     public $center;
+    
+    /** @var bool $vCenter Whether or not to center text vertically */
+    public $vCenter;
 
     /** @var int $width SVG width (px) */
     public $width;
@@ -44,6 +47,7 @@ class RendererModel
         "color" => "#36BCF7",
         "size" => "20",
         "center" => "false",
+        "vCenter" => "false",
         "width" => "400",
         "height" => "50",
         "multiline" => "false",
@@ -65,6 +69,7 @@ class RendererModel
         $this->color = $this->checkColor($params["color"] ?? $this->DEFAULTS["color"]);
         $this->size = $this->checkNumber($params["size"] ?? $this->DEFAULTS["size"], "Font size");
         $this->center = $this->checkBoolean($params["center"] ?? $this->DEFAULTS["center"]);
+        $this->vCenter = $this->checkBoolean($params["vCenter"] ?? $this->DEFAULTS["vCenter"]);
         $this->width = $this->checkNumber($params["width"] ?? $this->DEFAULTS["width"], "Width");
         $this->height = $this->checkNumber($params["height"] ?? $this->DEFAULTS["height"], "Height");
         $this->multiline = $this->checkBoolean($params["multiline"] ?? $this->DEFAULTS["multiline"]);

--- a/src/templates/main.php
+++ b/src/templates/main.php
@@ -20,10 +20,15 @@
 <?php endif;?>
     </path>
     <text font-family='"<?php echo $font ?>", monospace' fill='<?php echo $color ?>' font-size='<?php echo $size ?>'
-<?php if ($center): ?>
-        x='50%' dominant-baseline='middle' text-anchor='middle'>
+<?php if ($vCenter): ?>
+        dominant-baseline='middle'
 <?php else: ?>
-        x='0%' dominant-baseline='auto' text-anchor='start'>
+        dominant-baseline='auto'
+<?php endif;?>
+<?php if ($center): ?>
+        x='50%' text-anchor='middle'>
+<?php else: ?>
+        x='0%' text-anchor='start'>
 <?php endif;?>
         <textPath xlink:href='#path<?php echo $i ?>'>
             <?php echo $lines[$i] . "\n" ?>

--- a/src/views/RendererView.php
+++ b/src/views/RendererView.php
@@ -32,6 +32,7 @@ class RendererView
             "color" => $this->model->color,
             "size" => $this->model->size,
             "center" => $this->model->center,
+            "vCenter" => $this->model->vCenter,
             "width" => $this->model->width,
             "height" => $this->model->height,
             "multiline" => $this->model->multiline,

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -172,4 +172,30 @@ final class OptionsTest extends TestCase
         $model = new RendererModel("src/templates/main.php", $params, self::$database);
         $this->assertEquals(false, $model->center);
     }
+    
+    /**
+     * Test vCenter set to true
+     */
+    public function testVCenterIsTrue(): void
+    {
+        $params = array(
+            "lines" => "text",
+            "vCenter" => "true",
+        );
+        $model = new RendererModel("src/templates/main.php", $params, self::$database);
+        $this->assertEquals(true, $model->vCenter);
+    }
+
+    /**
+     * Test vCenter not set to true
+     */
+    public function testVCenterIsNotTrue(): void
+    {
+        $params = array(
+            "lines" => "text",
+            "vCenter" => "other",
+        );
+        $model = new RendererModel("src/templates/main.php", $params, self::$database);
+        $this->assertEquals(false, $model->vCenter);
+    }
 }

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -26,6 +26,7 @@ final class RendererTest extends TestCase
                 "Always learning new things",
             )),
             "center" => "true",
+            "vCenter" => "true",
             "width" => "380",
             "height" => "50",
         );
@@ -43,6 +44,7 @@ final class RendererTest extends TestCase
                 "Always learning new things",
             )),
             "center" => "true",
+            "vCenter" => "true",
             "width" => "380",
             "height" => "200",
             "multiline" => "true",
@@ -59,6 +61,7 @@ final class RendererTest extends TestCase
         // missing lines
         $params = array(
             "center" => "true",
+            "vCenter" => "true",
             "width" => "380",
             "height" => "50",
         );
@@ -94,6 +97,7 @@ final class RendererTest extends TestCase
                 "Always learning new things",
             )),
             "center" => "true",
+            "vCenter" => "true",
             "width" => "380",
             "font" => "Not-A-Font",
         );
@@ -116,10 +120,31 @@ final class RendererTest extends TestCase
                 "",
             )),
             "center" => "true",
+            "vCenter" => "true",
             "width" => "380",
             "height" => "50",
         );
         $controller = new RendererController($params, self::$database);
         $this->assertEquals(file_get_contents("tests/svg/test_normal.svg"), $controller->render());
+    }
+    
+    /**
+     * Test normal vertical alignment
+     */
+    public function testNormalVerticalAlignment(): void
+    {
+        $params = array(
+            "lines" => implode(";", array(
+                "Full-stack web and app developer",
+                "Self-taught UI/UX Designer",
+                "10+ years of coding experience",
+                "Always learning new things",
+            )),
+            "center" => "true",
+            "width" => "380",
+            "height" => "50",
+        );
+        $controller = new RendererController($params, self::$database);
+        $this->assertEquals(file_get_contents("tests/svg/test_normal_vertical_alignment.svg"), $controller->render());
     }
 }

--- a/tests/svg/test_fonts.svg
+++ b/tests/svg/test_fonts.svg
@@ -19,7 +19,8 @@
             values='m0,25 h0 ; m0,25 h400 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
     </path>
     <text font-family='"Roboto", monospace' fill='#36BCF7' font-size='20'
-        x='0%' dominant-baseline='auto' text-anchor='start'>
+        dominant-baseline='auto'
+        x='0%' text-anchor='start'>
         <textPath xlink:href='#path0'>
             text
         </textPath>

--- a/tests/svg/test_missing_lines.svg
+++ b/tests/svg/test_missing_lines.svg
@@ -5,7 +5,8 @@
     width='400px' height='50px'>
 
     <text font-family='monospace' fill='#c00' font-size='18'
-        y="50%" x='50%' dominant-baseline='middle' text-anchor='middle'>
+        dominant-baseline='middle'
+        y="50%" x='50%' text-anchor='middle'>
         Lines parameter must be set.
     </text>
 </svg>

--- a/tests/svg/test_missing_lines.svg
+++ b/tests/svg/test_missing_lines.svg
@@ -5,8 +5,7 @@
     width='400px' height='50px'>
 
     <text font-family='monospace' fill='#c00' font-size='18'
-        dominant-baseline='middle'
-        y="50%" x='50%' text-anchor='middle'>
+        y="50%" x='50%' dominant-baseline='middle' text-anchor='middle'>
         Lines parameter must be set.
     </text>
 </svg>

--- a/tests/svg/test_multiline.svg
+++ b/tests/svg/test_multiline.svg
@@ -11,7 +11,8 @@
             values='m0,25 h0 ; m0,25 h0 ; m0,25 h380' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
-        x='50%' dominant-baseline='middle' text-anchor='middle'>
+        dominant-baseline='middle'
+        x='50%' text-anchor='middle'>
         <textPath xlink:href='#path0'>
             Full-stack web and app developer
         </textPath>
@@ -23,7 +24,8 @@
             values='m0,50 h0 ; m0,50 h0 ; m0,50 h380' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
-        x='50%' dominant-baseline='middle' text-anchor='middle'>
+        dominant-baseline='middle'
+        x='50%' text-anchor='middle'>
         <textPath xlink:href='#path1'>
             Self-taught UI/UX Designer
         </textPath>
@@ -35,7 +37,8 @@
             values='m0,75 h0 ; m0,75 h0 ; m0,75 h380' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
-        x='50%' dominant-baseline='middle' text-anchor='middle'>
+        dominant-baseline='middle'
+        x='50%' text-anchor='middle'>
         <textPath xlink:href='#path2'>
             10+ years of coding experience
         </textPath>
@@ -47,7 +50,8 @@
             values='m0,100 h0 ; m0,100 h0 ; m0,100 h380' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
-        x='50%' dominant-baseline='middle' text-anchor='middle'>
+        dominant-baseline='middle'
+        x='50%' text-anchor='middle'>
         <textPath xlink:href='#path3'>
             Always learning new things
         </textPath>

--- a/tests/svg/test_normal.svg
+++ b/tests/svg/test_normal.svg
@@ -10,7 +10,8 @@
             values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
-        x='50%' dominant-baseline='middle' text-anchor='middle'>
+        dominant-baseline='middle'
+        x='50%' text-anchor='middle'>
         <textPath xlink:href='#path0'>
             Full-stack web and app developer
         </textPath>
@@ -21,7 +22,8 @@
             values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
-        x='50%' dominant-baseline='middle' text-anchor='middle'>
+        dominant-baseline='middle'
+        x='50%' text-anchor='middle'>
         <textPath xlink:href='#path1'>
             Self-taught UI/UX Designer
         </textPath>
@@ -32,7 +34,8 @@
             values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
-        x='50%' dominant-baseline='middle' text-anchor='middle'>
+        dominant-baseline='middle'
+        x='50%' text-anchor='middle'>
         <textPath xlink:href='#path2'>
             10+ years of coding experience
         </textPath>
@@ -43,7 +46,8 @@
             values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
-        x='50%' dominant-baseline='middle' text-anchor='middle'>
+        dominant-baseline='middle'
+        x='50%' text-anchor='middle'>
         <textPath xlink:href='#path3'>
             Always learning new things
         </textPath>

--- a/tests/svg/test_normal_vertical_alignment.svg
+++ b/tests/svg/test_normal_vertical_alignment.svg
@@ -1,0 +1,56 @@
+<!-- https://github.com/DenverCoder1/readme-typing-svg/ -->
+<svg xmlns='http://www.w3.org/2000/svg'
+    xmlns:xlink='http://www.w3.org/1999/xlink'
+    viewBox='0 0 380 50'
+    width='380px' height='50px'>
+
+    
+    <path id='path0'>
+        <animate id='d0' attributeName='d' begin='0s;d3.end' dur='5s'
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+    </path>
+    <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
+        dominant-baseline='auto'
+        x='50%' text-anchor='middle'>
+        <textPath xlink:href='#path0'>
+            Full-stack web and app developer
+        </textPath>
+    </text>
+
+    <path id='path1'>
+        <animate id='d1' attributeName='d' begin='d0.end' dur='5s'
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+    </path>
+    <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
+        dominant-baseline='auto'
+        x='50%' text-anchor='middle'>
+        <textPath xlink:href='#path1'>
+            Self-taught UI/UX Designer
+        </textPath>
+    </text>
+
+    <path id='path2'>
+        <animate id='d2' attributeName='d' begin='d1.end' dur='5s'
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+    </path>
+    <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
+        dominant-baseline='auto'
+        x='50%' text-anchor='middle'>
+        <textPath xlink:href='#path2'>
+            10+ years of coding experience
+        </textPath>
+    </text>
+
+    <path id='path3'>
+        <animate id='d3' attributeName='d' begin='d2.end' dur='5s'
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+    </path>
+    <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
+        dominant-baseline='auto'
+        x='50%' text-anchor='middle'>
+        <textPath xlink:href='#path3'>
+            Always learning new things
+        </textPath>
+    </text>
+
+</svg>


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. -->

Fixes #27

This PR adds the feature to control the vertical alignment over a new query param call `vCenter`. The vertical alignment was previously coupled with the horizontal alignment and controlled over `center`. With this PR we now separate the control over them.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. -->

- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other pull requests are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings