### PR TITLE
docs: Change examples list to profile pictures

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,21 @@ Here you can easily customize your Typing SVG with a live preview.
 
 ## 🚀 Example usage
 
-- **[Jonah Lawrence](https://github.com/DenverCoder1)**
-- **[Waren Gonzaga](https://github.com/warengonzaga)**
-- **[Eke Victor](https://github.com/Evavic44)**
-- **[8BitJonny](https://github.com/8BitJonny)**
-- **[Krish](https://github.com/krishdevdb)**
-- **[Aditya Raute](https://github.com/adityaraute)**
-- **[Shiva Sankeerth Reddy](https://github.com/ShivaSankeerth)**
-- **[Tarun Kamboj](https://github.com/Tarun-Kamboj)**
-- **[T.A.Vignesh](https://github.com/tavignesh)**
-- **[Angelo Fallaria](https://github.com/angelofallars)**
-- **[William J. Ghelfi](https://github.com/trumbitta)**
-- **[Shivam Yadav](https://github.com/sudoshivam)**
-- **[Adam Ross](https://github.com/R055A)**
+Below are links to profiles where you can see Readme Typing SVGs in action!
+
+[![Jonah Lawrence](https://github.com/DenverCoder1.png?size=60)](https://github.com/DenverCoder1)
+[![Waren Gonzaga](https://github.com/warengonzaga.png?size=60)](https://github.com/warengonzaga)
+[![Eke Victor](https://github.com/Evavic44.png?size=60)](https://github.com/Evavic44)
+[![8BitJonny](https://github.com/8BitJonny.png?size=60)](https://github.com/8BitJonny)
+[![Krish](https://github.com/krishdevdb.png?size=60)](https://github.com/krishdevdb)
+[![Aditya Raute](https://github.com/adityaraute.png?size=60)](https://github.com/adityaraute)
+[![Shiva Sankeerth Reddy](https://github.com/ShivaSankeerth.png?size=60)](https://github.com/ShivaSankeerth)
+[![Tarun Kamboj](https://github.com/Tarun-Kamboj.png?size=60)](://github.com/Tarun-Kamboj)
+[![T.A.Vignesh](https://github.com/tavignesh.png?size=60)](https://github.com/tavignesh)
+[![Angelo Fallaria](https://github.com/angelofallars.png?size=60)](https://github.com/angelofallars)
+[![William J. Ghelfi](https://github.com/trumbitta.png?size=60)](https://github.com/trumbitta)
+[![Shivam Yadav](https://github.com/sudoshivam.png?size=60)](https://github.com/sudoshivam)
+[![Adam Ross](https://github.com/R055A.png?size=60)](https://github.com/R055A)
 
 Feel free to [open a PR](https://github.com/DenverCoder1/readme-typing-svg/issues/21#issue-870549556) and add yours!
 


### PR DESCRIPTION
## Description

The examples list is getting pretty long and takes up a lot of space in the Readme.

To solve this, I have decided to switch all links to icons instead of list items.

![image](https://user-images.githubusercontent.com/20955511/135893095-05d0f2c1-26d5-4058-821f-801c612c0c4e.png)
