### PR TITLE
Change color picker to use hex instead of hexa

### DIFF
--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -59,7 +59,7 @@
 
                 <label for="color">Font color</label>
                 <input class="param jscolor jscolor-active" id="color" name="background"
-                    data-jscolor="{ format: 'hexa' }" value="#36BCF7">
+                    data-jscolor="{ format: 'hex' }" value="#36BCF7">
 
                 <label for="size">Font size</label>
                 <input class="param" type="number" id="size" name="size" placeholder="20" value="20">


### PR DESCRIPTION
## Description

Fixes #58 

### Type of change

- [x] Bug fix (added a non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran tests with `composer test`

## Checklist:

- [x] I have checked to make sure no other pull requests are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [x] My changes generate no new warnings
