### PR TITLE
fix: remove spaces from keyTimes for Safari

### DIFF
--- a/src/templates/main.php
+++ b/src/templates/main.php
@@ -11,11 +11,11 @@
     <path id='path<?php echo $i ?>'>
 <?php if (!$multiline): ?>
         <animate id='d<?php echo $i ?>' attributeName='d' begin='<?php echo ($i == 0 ? "0s;" : "") . $previousId ?>.end' dur='5s'
-            values='m0,<?php echo $height / 2 ?> h0 ; m0,<?php echo $height / 2 ?> h<?php echo $width ?> ; m0,<?php echo $height / 2 ?> h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,<?php echo $height / 2 ?> h0 ; m0,<?php echo $height / 2 ?> h<?php echo $width ?> ; m0,<?php echo $height / 2 ?> h0' keyTimes='0;0.8;1' />
 <?php else: ?>
     <?php $lineHeight = $size + 5;?>
     <animate id='d<?php echo $i ?>' attributeName='d' dur='<?php echo 5 * ($i + 1) ?>s' fill="freeze"
-            begin='0s;<?php echo "d" . (count($lines) - 1) ?>.end' keyTimes="0 ; <?php echo $i / ($i + 1); ?> ; 1"
+            begin='0s;<?php echo "d" . (count($lines) - 1) ?>.end' keyTimes="0;<?php echo $i / ($i + 1); ?>;1"
             values='m0,<?php echo ($i + 1) * $lineHeight ?> h0 ; m0,<?php echo ($i + 1) * $lineHeight ?> h0 ; m0,<?php echo ($i + 1) * $lineHeight ?> h<?php echo $width ?>' />
 <?php endif;?>
     </path>

--- a/tests/svg/test_fonts.svg
+++ b/tests/svg/test_fonts.svg
@@ -16,7 +16,7 @@
 	
     <path id='path0'>
         <animate id='d0' attributeName='d' begin='0s;d0.end' dur='5s'
-            values='m0,25 h0 ; m0,25 h400 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,25 h0 ; m0,25 h400 ; m0,25 h0' keyTimes='0;0.8;1' />
     </path>
     <text font-family='"Roboto", monospace' fill='#36BCF7' font-size='20'
         dominant-baseline='auto'

--- a/tests/svg/test_multiline.svg
+++ b/tests/svg/test_multiline.svg
@@ -7,7 +7,7 @@
     
     <path id='path0'>
         <animate id='d0' attributeName='d' dur='5s' fill="freeze"
-            begin='0s;d3.end' keyTimes="0 ; 0 ; 1"
+            begin='0s;d3.end' keyTimes="0;0;1"
             values='m0,25 h0 ; m0,25 h0 ; m0,25 h380' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
@@ -20,7 +20,7 @@
 
     <path id='path1'>
         <animate id='d1' attributeName='d' dur='10s' fill="freeze"
-            begin='0s;d3.end' keyTimes="0 ; 0.5 ; 1"
+            begin='0s;d3.end' keyTimes="0;0.5;1"
             values='m0,50 h0 ; m0,50 h0 ; m0,50 h380' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
@@ -33,7 +33,7 @@
 
     <path id='path2'>
         <animate id='d2' attributeName='d' dur='15s' fill="freeze"
-            begin='0s;d3.end' keyTimes="0 ; 0.66666666666667 ; 1"
+            begin='0s;d3.end' keyTimes="0;0.66666666666667;1"
             values='m0,75 h0 ; m0,75 h0 ; m0,75 h380' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
@@ -46,7 +46,7 @@
 
     <path id='path3'>
         <animate id='d3' attributeName='d' dur='20s' fill="freeze"
-            begin='0s;d3.end' keyTimes="0 ; 0.75 ; 1"
+            begin='0s;d3.end' keyTimes="0;0.75;1"
             values='m0,100 h0 ; m0,100 h0 ; m0,100 h380' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'

--- a/tests/svg/test_normal.svg
+++ b/tests/svg/test_normal.svg
@@ -7,7 +7,7 @@
     
     <path id='path0'>
         <animate id='d0' attributeName='d' begin='0s;d3.end' dur='5s'
-            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0;0.8;1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
         dominant-baseline='middle'
@@ -19,7 +19,7 @@
 
     <path id='path1'>
         <animate id='d1' attributeName='d' begin='d0.end' dur='5s'
-            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0;0.8;1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
         dominant-baseline='middle'
@@ -31,7 +31,7 @@
 
     <path id='path2'>
         <animate id='d2' attributeName='d' begin='d1.end' dur='5s'
-            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0;0.8;1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
         dominant-baseline='middle'
@@ -43,7 +43,7 @@
 
     <path id='path3'>
         <animate id='d3' attributeName='d' begin='d2.end' dur='5s'
-            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0;0.8;1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
         dominant-baseline='middle'

--- a/tests/svg/test_normal_vertical_alignment.svg
+++ b/tests/svg/test_normal_vertical_alignment.svg
@@ -7,7 +7,7 @@
     
     <path id='path0'>
         <animate id='d0' attributeName='d' begin='0s;d3.end' dur='5s'
-            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0;0.8;1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
         dominant-baseline='auto'
@@ -19,7 +19,7 @@
 
     <path id='path1'>
         <animate id='d1' attributeName='d' begin='d0.end' dur='5s'
-            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0;0.8;1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
         dominant-baseline='auto'
@@ -31,7 +31,7 @@
 
     <path id='path2'>
         <animate id='d2' attributeName='d' begin='d1.end' dur='5s'
-            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0;0.8;1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
         dominant-baseline='auto'
@@ -43,7 +43,7 @@
 
     <path id='path3'>
         <animate id='d3' attributeName='d' begin='d2.end' dur='5s'
-            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0 ; 0.8 ; 1' />
+            values='m0,25 h0 ; m0,25 h380 ; m0,25 h0' keyTimes='0;0.8;1' />
     </path>
     <text font-family='"monospace", monospace' fill='#36BCF7' font-size='20'
         dominant-baseline='auto'


### PR DESCRIPTION
## Description

Safari does not show animations when keyTimes contain spaces.

This removes spaces from keyTimes for compatibility with Safari.

Fixes #71 

### Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed a feature of the stats cards, please describe the tests you made to verify your changes. -->

- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

## Checklist:

- [x] I have checked to make sure no other pull requests are open for this issue
- [x] The code is properly formatted and is consistent with the existing code style
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

<!-- If you have updated the design or appearance, please include a screenshot of your changes. -->
