### PR TITLE
feat(demo): Updated demo site default values

### DIFF
--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -62,7 +62,7 @@
                         </svg>
                     </a>
                 </div>
-                <input class="param" type="text" id="font" name="font" alt="Font name" placeholder="monospace" value="monospace" pattern="^[A-Za-z0-9\- ]*$" title="Font from Google Fonts. Only letters, numbers, and spaces.">
+                <input class="param" type="text" id="font" name="font" alt="Font name" placeholder="Fira Code" value="Fira Code" pattern="^[A-Za-z0-9\- ]*$" title="Font from Google Fonts. Only letters, numbers, and spaces.">
 
                 <label for="size">Font size</label>
                 <input class="param" type="number" id="size" name="size" alt="Font size" placeholder="20" value="20">
@@ -71,7 +71,7 @@
                 <input class="param" type="number" id="duration" name="duration" alt="Print duration (ms)" placeholder="5000" value="5000">
 
                 <label for="pause">Pause (ms after line)</label>
-                <input class="param" type="number" id="pause" name="pause" alt="Pause duration (ms)" placeholder="500" value="500">
+                <input class="param" type="number" id="pause" name="pause" alt="Pause duration (ms)" placeholder="1000" value="1000">
 
                 <label for="color">Font color</label>
                 <input class="param jscolor jscolor-active" id="color" name="color" alt="Font color" data-jscolor="{ format: 'hexa' }" value="#36BCF7">
@@ -99,7 +99,7 @@
 
                 <label for="dimensions" title="Width ✕ Height">Width ✕ Height</label>
                 <span id="dimensions">
-                    <input class="param inline" type="number" id="width" name="width" alt="Width (px)" placeholder="400" value="400">
+                    <input class="param inline" type="number" id="width" name="width" alt="Width (px)" placeholder="435" value="435">
                     <label>✕</label>
                     <input class="param inline" type="number" id="height" name="height" alt="Height (px)" placeholder="50" value="50">
                 </span>


### PR DESCRIPTION
## Summary

Modified some preview values on the **Demo Site**.

**NOTE: The default values for typing SVGs have not changed, this change only affects the settings on the demo site.**

- Font changed from `monospace` to `Fira Code`
	- `monospace` has some issues in that it displays differently depending on the user's browser and can get cut off if the user has a wide monospace font installed. `Fira Code` is a specific font from Google fonts so should display the same width for all users.
- Pause changed from `500` to `1000`, it seems to be a better amount for a noticeable pause.
- Width changed from `400` to `435`. This width seems to work well when using Fira Code on the example pangram lines.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features
