### PR TITLE
ci: Change release to be on dispatch instead of push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Releases
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   changelog:


### PR DESCRIPTION
## Summary

Change release to be on dispatch instead of push. Some changes are pretty small and don't really require their own release. This allows more easily combining commits in a single release.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Updated documentation (updated the readme, templates, or other repo files)
