### PR TITLE
style: replace `<?php echo` with `<?=` shorthand

### DIFF
--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -30,7 +30,7 @@
     <link rel="icon" type="image/png" href="favicon.png">
 </head>
 
-<body <?php echo (isset($_COOKIE["darkmode"]) && $_COOKIE["darkmode"] == "on") ? 'data-theme="dark"' : ""; ?>>
+<body <?= (isset($_COOKIE["darkmode"]) && $_COOKIE["darkmode"] == "on") ? 'data-theme="dark"' : ""; ?>>
     <h1>⌨️ Readme Typing SVG</h1>
 
     <!-- GitHub badges/links section -->
@@ -142,7 +142,7 @@
     </div>
 
     <a href="javascript:toggleTheme()" class="darkmode" title="toggle dark mode">
-        <i class="<?php echo (isset($_COOKIE["darkmode"]) && $_COOKIE["darkmode"] == "on") ? 'gg-sun' : "gg-moon"; ?>"></i>
+        <i class="<?= (isset($_COOKIE["darkmode"]) && $_COOKIE["darkmode"] == "on") ? 'gg-sun' : "gg-moon"; ?>"></i>
     </a>
 </body>
 

--- a/src/templates/error.php
+++ b/src/templates/error.php
@@ -6,6 +6,6 @@
 
     <text font-family='monospace' fill='#c00' font-size='18'
         y="50%" x='50%' dominant-baseline='middle' text-anchor='middle'>
-        <?php echo $message . "\n" ?>
+        <?= $message . "\n" ?>
     </text>
 </svg>

--- a/src/templates/main.php
+++ b/src/templates/main.php
@@ -1,27 +1,27 @@
 <!-- https://github.com/DenverCoder1/readme-typing-svg/ -->
 <svg xmlns='http://www.w3.org/2000/svg'
     xmlns:xlink='http://www.w3.org/1999/xlink'
-    viewBox='0 0 <?php echo "$width $height" ?>'
-    style='background-color: <?php echo $background ?>;'
-    width='<?php echo $width ?>px' height='<?php echo $height ?>px'>
+    viewBox='0 0 <?= "$width $height" ?>'
+    style='background-color: <?= $background ?>;'
+    width='<?= $width ?>px' height='<?= $height ?>px'>
 
-    <?php echo preg_replace("/\n/", "\n\t", $fontCSS); ?>
+    <?= preg_replace("/\n/", "\n\t", $fontCSS); ?>
 
 <?php $previousId = "d" . (count($lines) - 1);?>
 <?php for ($i = 0; $i < count($lines); ++$i): ?>
-    <path id='path<?php echo $i ?>'>
+    <path id='path<?= $i ?>'>
 <?php if (!$multiline): ?>
-        <animate id='d<?php echo $i ?>' attributeName='d' begin='<?php echo ($i == 0 ? "0s;" : "") . $previousId ?>.end' dur='<?php echo $duration + $pause ?>ms'
-            values='m0,<?php echo $height / 2 ?> h0 ; m0,<?php echo $height / 2 ?> h<?php echo $width ?> ; m0,<?php echo $height / 2 ?> h<?php echo $width ?> ; m0,<?php echo $height / 2 ?> h0'
-            keyTimes='0;<?php echo 0.8 * $duration / ($duration + $pause) ?>;<?php echo (0.8 * $duration + $pause) / ($duration + $pause) ?>;1' />
+        <animate id='d<?= $i ?>' attributeName='d' begin='<?= ($i == 0 ? "0s;" : "") . $previousId ?>.end' dur='<?= $duration + $pause ?>ms'
+            values='m0,<?= $height / 2 ?> h0 ; m0,<?= $height / 2 ?> h<?= $width ?> ; m0,<?= $height / 2 ?> h<?= $width ?> ; m0,<?= $height / 2 ?> h0'
+            keyTimes='0;<?= 0.8 * $duration / ($duration + $pause) ?>;<?= (0.8 * $duration + $pause) / ($duration + $pause) ?>;1' />
 <?php else: ?>
     <?php $lineHeight = $size + 5;?>
-    <animate id='d<?php echo $i ?>' attributeName='d' dur='<?php echo ($duration + $pause) * ($i + 1) ?>ms' fill="freeze"
-            begin='0s;<?php echo "d" . (count($lines) - 1) ?>.end' keyTimes="0;<?php echo $i / ($i + 1); ?>;<?php echo $i / ($i + 1) + $duration / (($duration + $pause) * ($i + 1)); ?>;1"
-            values='m0,<?php echo ($i + 1) * $lineHeight ?> h0 ; m0,<?php echo ($i + 1) * $lineHeight ?> h0 ; m0,<?php echo ($i + 1) * $lineHeight ?> h<?php echo $width ?> ; m0,<?php echo ($i + 1) * $lineHeight ?> h<?php echo $width ?>' />
+    <animate id='d<?= $i ?>' attributeName='d' dur='<?= ($duration + $pause) * ($i + 1) ?>ms' fill="freeze"
+            begin='0s;<?= "d" . (count($lines) - 1) ?>.end' keyTimes="0;<?= $i / ($i + 1); ?>;<?= $i / ($i + 1) + $duration / (($duration + $pause) * ($i + 1)); ?>;1"
+            values='m0,<?= ($i + 1) * $lineHeight ?> h0 ; m0,<?= ($i + 1) * $lineHeight ?> h0 ; m0,<?= ($i + 1) * $lineHeight ?> h<?= $width ?> ; m0,<?= ($i + 1) * $lineHeight ?> h<?= $width ?>' />
 <?php endif;?>
     </path>
-    <text font-family='"<?php echo $font ?>", monospace' fill='<?php echo $color ?>' font-size='<?php echo $size ?>'
+    <text font-family='"<?= $font ?>", monospace' fill='<?= $color ?>' font-size='<?= $size ?>'
 <?php if ($vCenter): ?>
         dominant-baseline='middle'
 <?php else: ?>
@@ -32,8 +32,8 @@
 <?php else: ?>
         x='0%' text-anchor='start'>
 <?php endif;?>
-        <textPath xlink:href='#path<?php echo $i ?>'>
-            <?php echo $lines[$i] . "\n" ?>
+        <textPath xlink:href='#path<?= $i ?>'>
+            <?= $lines[$i] . "\n" ?>
         </textPath>
     </text>
 


### PR DESCRIPTION
## Summary

Replace `<?php echo` with `<?=` shorthand for readability

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [x] Ran tests with `composer test`
