### PR TITLE
docs(readme): Added ProfCyberNaught to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Below are links to profiles where you can see Readme Typing SVGs in action!
 [![Maagnitude](https://github.com/Maagnitude.png?size=60)](https://github.com/Maagnitude)
 [![cracker911181](https://github.com/cracker911181.png?size=60)](https://github.com/cracker911181)
 [![quiet-node](https://github.com/quiet-node.png?size=60)](https://github.com/quiet-node)
-[![ProfCyberNaught](https://github.com/ProfCyberNaught.png?size=60)](https://github.com/ProfCyberNaught "ProfCyberNaught on GitHub")
+[![ProfCyberNaught](https://github.com/ProfCyberNaught.png?size=60)](https://github.com/ProfCyberNaught)
 
 Feel free to [open a PR](https://github.com/DenverCoder1/readme-typing-svg/issues/21#issue-870549556) and add yours!
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Below are links to profiles where you can see Readme Typing SVGs in action!
 [![Maagnitude](https://github.com/Maagnitude.png?size=60)](https://github.com/Maagnitude)
 [![cracker911181](https://github.com/cracker911181.png?size=60)](https://github.com/cracker911181)
 [![logann131](https://github.com/logann131.png?size=60)](https://github.com/logann131)
+[![ProfCyberNaught](https://github.com/ProfCyberNaught.png?size=60)](https://github.com/ProfCyberNaught "ProfCyberNaught on GitHub")
 
 Feel free to [open a PR](https://github.com/DenverCoder1/readme-typing-svg/issues/21#issue-870549556) and add yours!
 


### PR DESCRIPTION
Adding ProfCyberNaught to the example usage section as I am actively using this feature on my profile page on GitHub.

## Summary

I have been using this feature on my profile for a while now (at the very top) and notice, you were able to submit a pull request containing your own profile image and link to profile on GitHub. I think this is a great idea to demonstrate the usage scenario on active and engaged profiles.

I have added my own profile image, along with a link to my GitHub profile page, and the link title text: ProfCyberNaught on GitHub.

## Type of change

- [x] Updated documentation (updated the readme, templates, or other repo files)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [x] Ran checks in browser and checked for errors in spelling and URL image and profile links work
