### PR TITLE
fix: disable translation on key elements

### DIFF
--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -94,15 +94,15 @@
                 <input class="param jscolor jscolor-active" id="background" name="background" alt="Background color" data-jscolor="{ format: 'hexa' }" value="#00000000">
 
                 <label for="center">Horizontally Centered</label>
-                <select class="param" id="center" name="center" alt="Horizontally Centered" translate="no">
-                    <option>false</option>
-                    <option>true</option>
+                <select class="param" id="center" name="center" alt="Horizontally Centered">
+                    <option value="false">false</option>
+                    <option value="true">true</option>
                 </select>
 
                 <label for="vCenter">Vertically Centered</label>
-                <select class="param" id="vCenter" name="vCenter" alt="Vertically Centered" translate="no">
-                    <option>false</option>
-                    <option>true</option>
+                <select class="param" id="vCenter" name="vCenter" alt="Vertically Centered">
+                    <option value="false">false</option>
+                    <option value="true">true</option>
                 </select>
 
                 <label for="multiline">Multiline</label>
@@ -112,15 +112,15 @@
                 </select>
 
                 <label for="repeat">Repeat</label>
-                <select class="param" id="repeat" name="repeat" alt="Repeat" translate="no">
-                    <option>true</option>
-                    <option>false</option>
+                <select class="param" id="repeat" name="repeat" alt="Repeat">
+                    <option value="true">true</option>
+                    <option value="false">false</option>
                 </select>
 
                 <label for="random">Random</label>
-                <select class="param" id="random" name="random" alt="Random" translate="no">
-                    <option>false</option>
-                    <option>true</option>
+                <select class="param" id="random" name="random" alt="Random">
+                    <option value="false">false</option>
+                    <option value="true">true</option>
                 </select>
 
                 <label for="dimensions" title="Width ✕ Height">Width ✕ Height</label>

--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -94,13 +94,13 @@
                 <input class="param jscolor jscolor-active" id="background" name="background" alt="Background color" data-jscolor="{ format: 'hexa' }" value="#00000000">
 
                 <label for="center">Horizontally Centered</label>
-                <select class="param" id="center" name="center" alt="Horizontally Centered">
+                <select class="param" id="center" name="center" alt="Horizontally Centered" translate="no">
                     <option>false</option>
                     <option>true</option>
                 </select>
 
                 <label for="vCenter">Vertically Centered</label>
-                <select class="param" id="vCenter" name="vCenter" alt="Vertically Centered">
+                <select class="param" id="vCenter" name="vCenter" alt="Vertically Centered" translate="no">
                     <option>false</option>
                     <option>true</option>
                 </select>
@@ -112,13 +112,13 @@
                 </select>
 
                 <label for="repeat">Repeat</label>
-                <select class="param" id="repeat" name="repeat" alt="Repeat">
+                <select class="param" id="repeat" name="repeat" alt="Repeat" translate="no">
                     <option>true</option>
                     <option>false</option>
                 </select>
 
                 <label for="random">Random</label>
-                <select class="param" id="random" name="random" alt="Random">
+                <select class="param" id="random" name="random" alt="Random" translate="no">
                     <option>false</option>
                     <option>true</option>
                 </select>


### PR DESCRIPTION
## Summary

This change adds a mechanism (e.g., a `translate="no"` attribute) on key text elements to prevent Microsoft Edge from automatically translating specific words. This fix ensures that the intended text remains unchanged when using Edge's webpage translation feature.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (added a non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- If you have changed or added a feature, please describe the tests you made to verify your changes. -->

- [X] Ran tests with `composer test`

Additionally, the fix was verified manually by running the demo page in Microsoft Edge with translation enabled to ensure that key text remains unchanged.

Closes #336