### PR TITLE
Added rundowntown to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Below are links to profiles where you can see Readme Typing SVGs in action!
 [![wfxey](https://github.com/wfxey.png?size=60)](https://github.com/wfxey "wfxey on Github")
 [![Lixiao Zhu](https://github.com/zhulixiao.png?size=60)](https://github.com/zhulixiao "Lixiao Zhu on Github")
 [![Ahmed Nassar](https://github.com/AhmedNassar7.png?size=60)](https://github.com/AhmedNassar7 "Ahmed Nassar on Github")
-
+[![Daniel Forcade](https://github.com/rundowntown.png?size=60)](https://github.com/rundowntown "Daniel Forcade on Github")
 Feel free to [open a PR](https://github.com/DenverCoder1/readme-typing-svg/issues/21#issue-870549556) and add yours!
 
 ## 🔧 Options


### PR DESCRIPTION
I added my profile to the readme as specified.  

Some interesting uses I have for it: Readme is updated throughout the day to reflect time of day (colors, messages) with github actions.

The typing SVG had 8 messages for each time block, so throughout the day it will display 72 different thematic phrases.

## Summary

<!-- Added new profile (rundowntown) to readme -->

## Type of change

readme update (profile added: rundowntown)

## How Has This Been Tested?

