### PR TITLE
feat: Add grouped lines animation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Feel free to [open a PR](https://github.com/DenverCoder1/readme-typing-svg/issue
 |   `duration`    |     Duration of the printing of a single line in milliseconds (default: `5000`)     | integer |                                                Any positive number                                                |
 |     `pause`     |         Duration of the pause between lines in milliseconds (default: `0`)          | integer |                                              Any non-negative number                                              |
 |    `repeat`     |      `true` to loop around to the first line after the last (default: `true`)       | boolean |                                                 `true` or `false`                                                 |
-|    `groups`     | Group lines so each group types sequentially then clears together (default: `none`) | string  |                                `2,1` (first 2 lines as group 1, next 1 as group 2)                                |
+|    `groups`     | Group lines so each group types sequentially then clears together. Sizes must sum to the number of non-empty lines (default: `none`) | string  |                                `2,1` (first 2 lines as group 1, next 1 as group 2)                                |
 |   `separator`   |         Separator used between lines in the lines parameter (default: `;`)          | string  |                                               `;`, `;;`, `/`, etc.                                                |
 | `letterSpacing` |                         Letter spacing (default: `normal`)                          | string  | Any css values for the [letter-spacing](https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing) property |
 

--- a/README.md
+++ b/README.md
@@ -144,23 +144,24 @@ Feel free to [open a PR](https://github.com/DenverCoder1/readme-typing-svg/issue
 
 ## 🔧 Options
 
-|    Parameter    |                                   Details                                   |  Type   |                                                      Example                                                      |
-| :-------------: | :-------------------------------------------------------------------------: | :-----: | :---------------------------------------------------------------------------------------------------------------: |
-|     `lines`     |       Text to display with lines separated by `;` and `+` for spaces        | string  |                                        `First+line;Second+line;Third+line`                                        |
-|    `height`     |             Height of the output SVG in pixels (default: `50`)              | integer |                                                Any positive number                                                |
-|     `width`     |             Width of the output SVG in pixels (default: `400`)              | integer |                                                Any positive number                                                |
-|     `size`      |                     Font size in pixels (default: `20`)                     | integer |                                                Any positive number                                                |
-|     `font`      |                     Font family (default: `monospace`)                      | string  |                                            Any font from Google Fonts                                             |
-|     `color`     |                    Color of the text (default: `36BCF7`)                    | string  |                                         Hex code without # (eg. `F724A9`)                                         |
-|  `background`   |             Background color of the text (default: `00000000`)              | string  |                                         Hex code without # (eg. `FEFF4C`)                                         |
-|    `center`     |    `true` to center text or `false` for left aligned (default: `false`)     | boolean |                                                 `true` or `false`                                                 |
-|    `vCenter`    |  `true` to center vertically or `false`(default) to align above the center  | boolean |                                                 `true` or `false`                                                 |
-|   `multiline`   |  `true` to wrap lines or `false` to retype on one line (default: `false`)   | boolean |                                                 `true` or `false`                                                 |
-|   `duration`    | Duration of the printing of a single line in milliseconds (default: `5000`) | integer |                                                Any positive number                                                |
-|     `pause`     |     Duration of the pause between lines in milliseconds (default: `0`)      | integer |                                              Any non-negative number                                              |
-|    `repeat`     |  `true` to loop around to the first line after the last (default: `true`)   | boolean |                                                 `true` or `false`                                                 |
-|   `separator`   |     Separator used between lines in the lines parameter (default: `;`)      | string  |                                               `;`, `;;`, `/`, etc.                                                |
-| `letterSpacing` |                     Letter spacing (default: `normal`)                      | string  | Any css values for the [letter-spacing](https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing) property |
+|    Parameter    |                                       Details                                       |  Type   |                                                      Example                                                      |
+| :-------------: | :---------------------------------------------------------------------------------: | :-----: | :---------------------------------------------------------------------------------------------------------------: |
+|     `lines`     |           Text to display with lines separated by `;` and `+` for spaces            | string  |                                        `First+line;Second+line;Third+line`                                        |
+|    `height`     |                 Height of the output SVG in pixels (default: `50`)                  | integer |                                                Any positive number                                                |
+|     `width`     |                 Width of the output SVG in pixels (default: `400`)                  | integer |                                                Any positive number                                                |
+|     `size`      |                         Font size in pixels (default: `20`)                         | integer |                                                Any positive number                                                |
+|     `font`      |                         Font family (default: `monospace`)                          | string  |                                            Any font from Google Fonts                                             |
+|     `color`     |                        Color of the text (default: `36BCF7`)                        | string  |                                         Hex code without # (eg. `F724A9`)                                         |
+|  `background`   |                 Background color of the text (default: `00000000`)                  | string  |                                         Hex code without # (eg. `FEFF4C`)                                         |
+|    `center`     |        `true` to center text or `false` for left aligned (default: `false`)         | boolean |                                                 `true` or `false`                                                 |
+|    `vCenter`    |      `true` to center vertically or `false`(default) to align above the center      | boolean |                                                 `true` or `false`                                                 |
+|   `multiline`   |      `true` to wrap lines or `false` to retype on one line (default: `false`)       | boolean |                                                 `true` or `false`                                                 |
+|   `duration`    |     Duration of the printing of a single line in milliseconds (default: `5000`)     | integer |                                                Any positive number                                                |
+|     `pause`     |         Duration of the pause between lines in milliseconds (default: `0`)          | integer |                                              Any non-negative number                                              |
+|    `repeat`     |      `true` to loop around to the first line after the last (default: `true`)       | boolean |                                                 `true` or `false`                                                 |
+|    `groups`     | Group lines so each group types sequentially then clears together (default: `none`) | string  |                                `2,1` (first 2 lines as group 1, next 1 as group 2)                                |
+|   `separator`   |         Separator used between lines in the lines parameter (default: `;`)          | string  |                                               `;`, `;;`, `/`, etc.                                                |
+| `letterSpacing` |                         Letter spacing (default: `normal`)                          | string  | Any css values for the [letter-spacing](https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing) property |
 
 ## 📤 Deploying it on your own
 

--- a/src/demo/css/style.css
+++ b/src/demo/css/style.css
@@ -101,7 +101,9 @@ h2 {
   border-radius: 6px;
   cursor: pointer;
   font-family: inherit;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.24);
   transition: 0.2s ease-in-out;
 }
 
@@ -111,7 +113,9 @@ h2 {
 
 .btn:not(:disabled):hover {
   background-color: var(--blue-dark);
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  box-shadow:
+    0 3px 6px rgba(0, 0, 0, 0.16),
+    0 3px 6px rgba(0, 0, 0, 0.23);
 }
 
 .btn:disabled {
@@ -196,7 +200,9 @@ input:invalid {
 
 input:focus:invalid {
   outline: none;
-  box-shadow: 0 0 0 1px var(--blue-light), 0 0 0 3px var(--red);
+  box-shadow:
+    0 0 0 1px var(--blue-light),
+    0 0 0 3px var(--red);
 }
 
 .delete-line.btn {
@@ -213,7 +219,9 @@ input:focus:invalid {
 }
 
 .delete-line.btn:not(:disabled):hover {
-  box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
+  box-shadow:
+    0 1px 3px rgb(0 0 0 / 12%),
+    0 1px 2px rgb(0 0 0 / 24%);
   background: #e4535314;
 }
 
@@ -223,22 +231,35 @@ input:focus:invalid {
 
 .group-divider {
   grid-column: 1 / -1;
-  display: flex;
+  /* display:none gives a true zero grid footprint (no row, no surrounding gap);
+     opacity/height would still reserve space and leave large gaps between lines. */
+  display: none;
   align-items: center;
   gap: 6px;
   height: 18px;
   cursor: pointer;
   user-select: none;
-  opacity: 0;
-  transition: opacity 0.15s;
+  opacity: 0.4;
+  /* Reset: divider is a real <button> so it is keyboard focusable/activatable */
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
+}
+
+/* focus-within reveals the dividers before Tab order reaches them, so keyboard users can land on the buttons to create groups. */
+.lines:hover .group-divider,
+.lines:focus-within .group-divider,
+.group-divider.active {
+  display: flex;
 }
 
 .group-divider:hover,
-.lines:hover .group-divider {
-  opacity: 0.4;
-}
-
-.group-divider:hover {
+.group-divider:focus-visible {
   opacity: 0.7;
 }
 
@@ -252,7 +273,9 @@ input:focus:invalid {
   flex: 1;
   height: 1px;
   background: var(--stroke);
-  transition: background 0.15s, height 0.15s;
+  transition:
+    background 0.15s,
+    height 0.15s;
 }
 
 .group-divider.active::before,

--- a/src/demo/css/style.css
+++ b/src/demo/css/style.css
@@ -101,7 +101,9 @@ h2 {
   border-radius: 6px;
   cursor: pointer;
   font-family: inherit;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.24);
   transition: 0.2s ease-in-out;
 }
 
@@ -111,7 +113,9 @@ h2 {
 
 .btn:not(:disabled):hover {
   background-color: var(--blue-dark);
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+  box-shadow:
+    0 3px 6px rgba(0, 0, 0, 0.16),
+    0 3px 6px rgba(0, 0, 0, 0.23);
 }
 
 .btn:disabled {
@@ -196,7 +200,9 @@ input:invalid {
 
 input:focus:invalid {
   outline: none;
-  box-shadow: 0 0 0 1px var(--blue-light), 0 0 0 3px var(--red);
+  box-shadow:
+    0 0 0 1px var(--blue-light),
+    0 0 0 3px var(--red);
 }
 
 .delete-line.btn {
@@ -213,12 +219,70 @@ input:focus:invalid {
 }
 
 .delete-line.btn:not(:disabled):hover {
-  box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
+  box-shadow:
+    0 1px 3px rgb(0 0 0 / 12%),
+    0 1px 2px rgb(0 0 0 / 24%);
   background: #e4535314;
 }
 
 .delete-line.btn:disabled {
   color: var(--stroke);
+}
+
+.group-divider {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 18px;
+  cursor: pointer;
+  user-select: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.group-divider:hover,
+.lines:hover .group-divider {
+  opacity: 0.4;
+}
+
+.group-divider:hover {
+  opacity: 0.7;
+}
+
+.group-divider.active {
+  opacity: 1;
+}
+
+.group-divider::before,
+.group-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--stroke);
+  transition:
+    background 0.15s,
+    height 0.15s;
+}
+
+.group-divider.active::before,
+.group-divider.active::after {
+  height: 2px;
+  background: var(--blue-light);
+}
+
+.group-divider-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  color: var(--stroke);
+  transition: color 0.15s;
+}
+
+.group-divider.active .group-divider-label {
+  color: var(--blue-light);
+  font-weight: 600;
 }
 
 .add-line.btn {

--- a/src/demo/css/style.css
+++ b/src/demo/css/style.css
@@ -101,9 +101,7 @@ h2 {
   border-radius: 6px;
   cursor: pointer;
   font-family: inherit;
-  box-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.12),
-    0 1px 2px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
   transition: 0.2s ease-in-out;
 }
 
@@ -113,9 +111,7 @@ h2 {
 
 .btn:not(:disabled):hover {
   background-color: var(--blue-dark);
-  box-shadow:
-    0 3px 6px rgba(0, 0, 0, 0.16),
-    0 3px 6px rgba(0, 0, 0, 0.23);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
 }
 
 .btn:disabled {
@@ -200,9 +196,7 @@ input:invalid {
 
 input:focus:invalid {
   outline: none;
-  box-shadow:
-    0 0 0 1px var(--blue-light),
-    0 0 0 3px var(--red);
+  box-shadow: 0 0 0 1px var(--blue-light), 0 0 0 3px var(--red);
 }
 
 .delete-line.btn {
@@ -219,9 +213,7 @@ input:focus:invalid {
 }
 
 .delete-line.btn:not(:disabled):hover {
-  box-shadow:
-    0 1px 3px rgb(0 0 0 / 12%),
-    0 1px 2px rgb(0 0 0 / 24%);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
   background: #e4535314;
 }
 
@@ -260,9 +252,7 @@ input:focus:invalid {
   flex: 1;
   height: 1px;
   background: var(--stroke);
-  transition:
-    background 0.15s,
-    height 0.15s;
+  transition: background 0.15s, height 0.15s;
 }
 
 .group-divider.active::before,

--- a/src/demo/css/toggle-dark.css
+++ b/src/demo/css/toggle-dark.css
@@ -11,7 +11,9 @@ a.darkmode {
   justify-content: center;
   border-radius: 50%;
   border: 2px solid var(--border);
-  box-shadow: 0 0 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
+  box-shadow:
+    0 0 3px rgb(0 0 0 / 12%),
+    0 1px 2px rgb(0 0 0 / 24%);
   transition: 0.2s ease-in box-shadow;
 }
 
@@ -45,7 +47,9 @@ a.darkmode .icon-sun {
 }
 
 a.darkmode:hover {
-  box-shadow: 0 0 6px rgb(0 0 0 / 16%), 0 3px 6px rgb(0 0 0 / 23%);
+  box-shadow:
+    0 0 6px rgb(0 0 0 / 16%),
+    0 3px 6px rgb(0 0 0 / 23%);
 }
 
 @media only screen and (max-width: 600px) {

--- a/src/demo/css/toggle-dark.css
+++ b/src/demo/css/toggle-dark.css
@@ -11,9 +11,7 @@ a.darkmode {
   justify-content: center;
   border-radius: 50%;
   border: 2px solid var(--border);
-  box-shadow:
-    0 0 3px rgb(0 0 0 / 12%),
-    0 1px 2px rgb(0 0 0 / 24%);
+  box-shadow: 0 0 3px rgb(0 0 0 / 12%), 0 1px 2px rgb(0 0 0 / 24%);
   transition: 0.2s ease-in box-shadow;
 }
 
@@ -47,9 +45,7 @@ a.darkmode .icon-sun {
 }
 
 a.darkmode:hover {
-  box-shadow:
-    0 0 6px rgb(0 0 0 / 16%),
-    0 3px 6px rgb(0 0 0 / 23%);
+  box-shadow: 0 0 6px rgb(0 0 0 / 16%), 0 3px 6px rgb(0 0 0 / 23%);
 }
 
 @media only screen and (max-width: 600px) {

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -78,6 +78,20 @@ const preview = {
       }
     }
     params.lines = mergeLines(lineInputs, params.separator);
+    // backend validates sum(groups) == line count, so skip empty inputs
+    const activeDividers = Array.from(document.querySelectorAll(".group-divider.active"));
+    if (activeDividers.length > 0) {
+      const breaks = activeDividers.map((d) => Number(d.dataset.dividerAfter)).sort((a, b) => a - b);
+      const segments = [0, ...breaks, lineInputs.length];
+      const groups = [];
+      for (let i = 0; i < segments.length - 1; i++) {
+        const count = lineInputs.slice(segments[i], segments[i + 1]).filter((el) => el.value.length > 0).length;
+        if (count > 0) groups.push(count);
+      }
+      if (groups.length > 1) {
+        params.groups = groups.join(",");
+      }
+    }
     return params;
   },
 
@@ -128,6 +142,23 @@ const preview = {
   },
 
   /**
+   * Create a clickable group divider element
+   * @param {number} afterIndex The line index this divider sits after
+   * @returns {HTMLElement} The divider element
+   */
+  createDivider(afterIndex) {
+    const divider = document.createElement("div");
+    divider.className = "group-divider";
+    divider.dataset.dividerAfter = afterIndex;
+    divider.title = "Click to split into separate groups";
+    divider.innerHTML = '<span class="group-divider-label">new group</span>';
+    divider.addEventListener("click", function () {
+      this.classList.toggle("active");
+    });
+    return divider;
+  },
+
+  /**
    * Add new line input fields
    * @param {number} count The number of lines to add
    * @returns {false} Always returns false to prevent form submission
@@ -136,6 +167,9 @@ const preview = {
     for (let i = 0; i < count; i++) {
       const parent = document.querySelector(".lines");
       const index = parent.querySelectorAll("input").length + 1;
+      if (index > 1) {
+        parent.appendChild(this.createDivider(index - 1));
+      }
       // label
       const label = document.createElement("label");
       label.innerText = `Line ${index}`;
@@ -184,6 +218,17 @@ const preview = {
     parent.querySelectorAll(`[data-index="${index}"]`).forEach((el) => {
       parent.removeChild(el);
     });
+    // first line has no preceding divider, so fall back to removing divider after line 1
+    const dividerToRemove = index > 1 ? index - 1 : 1;
+    const divider = parent.querySelector(`.group-divider[data-divider-after="${dividerToRemove}"]`);
+    if (divider) parent.removeChild(divider);
+    // divider positions shift down when a line is removed
+    parent.querySelectorAll(".group-divider").forEach((div) => {
+      const afterIndex = Number(div.dataset.dividerAfter);
+      if (afterIndex >= index) {
+        div.dataset.dividerAfter = afterIndex - 1;
+      }
+    });
     // update index numbers
     const labels = parent.querySelectorAll("label");
     labels.forEach((label) => {
@@ -225,8 +270,8 @@ const preview = {
     // reset all inputs
     const inputs = document.querySelectorAll(".param");
     inputs.forEach((input) => {
-      let value = this.overrides[input.name] || this.defaults[input.name];
-      if (value) {
+      let value = this.overrides[input.name] ?? this.defaults[input.name];
+      if (value !== undefined) {
         if (["color", "background"].includes(input.name)) {
           input.jscolor.fromString(value);
         } else {
@@ -234,6 +279,7 @@ const preview = {
         }
       }
     });
+    document.querySelectorAll(".group-divider.active").forEach((d) => d.classList.remove("active"));
   },
 
   /**
@@ -267,12 +313,16 @@ const preview = {
   restore() {
     // get parameters from URL
     const urlParams = new URLSearchParams(window.location.search);
-    const params = { ...this.defaults, ...this.overrides, ...Object.fromEntries(urlParams) };
+    const params = {
+      ...this.defaults,
+      ...this.overrides,
+      ...Object.fromEntries(urlParams),
+    };
     // set all parameters
     const inputs = document.querySelectorAll(".param");
     inputs.forEach((input) => {
       let value = params[input.name];
-      if (value) {
+      if (value !== undefined) {
         if (["color", "background"].includes(input.name)) {
           input.jscolor.fromString(value);
         } else {
@@ -287,6 +337,17 @@ const preview = {
     lineInputs.forEach((line, index) => {
       document.querySelector(`#line-${index + 1}`).value = line;
     });
+    // groups param stores sizes, need to convert to cumulative positions for divider activation
+    const groupsParam = urlParams.get("groups");
+    if (groupsParam) {
+      const sizes = groupsParam.split(",").map(Number);
+      let pos = 0;
+      for (let i = 0; i < sizes.length - 1; i++) {
+        pos += sizes[i];
+        const divider = document.querySelector(`.group-divider[data-divider-after="${pos}"]`);
+        if (divider) divider.classList.add("active");
+      }
+    }
   },
 };
 
@@ -348,5 +409,5 @@ window.addEventListener(
     preview.restore(); // restore parameters
     preview.update(); // update preview
   },
-  false
+  false,
 );

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -411,5 +411,5 @@ window.addEventListener(
     preview.restore(); // restore parameters
     preview.update(); // update preview
   },
-  false,
+  false
 );

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -219,13 +219,19 @@ const preview = {
   removeLine(index) {
     index = Number(index);
     const parent = document.querySelector(".lines");
+    // A line has a divider on each side; if either was an active group boundary the
+    // boundary must survive when the two neighbouring lines merge into one gap.
+    const prevDivider = parent.querySelector(`.group-divider[data-divider-after="${index - 1}"]`);
+    const nextDivider = parent.querySelector(`.group-divider[data-divider-after="${index}"]`);
+    const boundarySurvives =
+      (prevDivider && prevDivider.classList.contains("active")) ||
+      (nextDivider && nextDivider.classList.contains("active"));
     // remove all elements for given property
     parent.querySelectorAll(`[data-index="${index}"]`).forEach((el) => {
       parent.removeChild(el);
     });
-    // DOM layout: [Line 1] [divider after=1] [Line 2] [divider after=2] [Line 3]
-    // Remove the divider before the deleted line (index-1), except line 1
-    // has no preceding divider, so remove the one after it instead
+    // Remove the divider before the deleted line (index-1); line 1 has no preceding
+    // divider, so remove the one after it instead.
     const dividerToRemove = index > 1 ? index - 1 : 1;
     const divider = parent.querySelector(`.group-divider[data-divider-after="${dividerToRemove}"]`);
     if (divider) parent.removeChild(divider);
@@ -236,6 +242,11 @@ const preview = {
         div.dataset.dividerAfter = afterIndex - 1;
       }
     });
+    // nextDivider has shifted into the merged gap; re-activate it if a boundary was lost.
+    if (index > 1 && nextDivider && boundarySurvives) {
+      nextDivider.classList.add("active");
+      nextDivider.setAttribute("aria-pressed", "true");
+    }
     // update index numbers
     const labels = parent.querySelectorAll("label");
     labels.forEach((label) => {

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -147,13 +147,18 @@ const preview = {
    * @returns {HTMLElement} The divider element
    */
   createDivider(afterIndex) {
-    const divider = document.createElement("div");
+    // Button element so the divider is keyboard focusable and activatable; type=button stops it submitting the form.
+    const divider = document.createElement("button");
+    divider.type = "button";
     divider.className = "group-divider";
     divider.dataset.dividerAfter = afterIndex;
     divider.title = "Click to split into separate groups";
+    divider.setAttribute("aria-label", "Toggle group break");
+    divider.setAttribute("aria-pressed", "false");
     divider.innerHTML = '<span class="group-divider-label">new group</span>';
     divider.addEventListener("click", function () {
-      this.classList.toggle("active");
+      const active = this.classList.toggle("active");
+      this.setAttribute("aria-pressed", String(active));
     });
     return divider;
   },
@@ -281,7 +286,10 @@ const preview = {
         }
       }
     });
-    document.querySelectorAll(".group-divider.active").forEach((d) => d.classList.remove("active"));
+    document.querySelectorAll(".group-divider.active").forEach((d) => {
+      d.classList.remove("active");
+      d.setAttribute("aria-pressed", "false");
+    });
   },
 
   /**
@@ -347,7 +355,10 @@ const preview = {
       for (let i = 0; i < sizes.length - 1; i++) {
         pos += sizes[i];
         const divider = document.querySelector(`.group-divider[data-divider-after="${pos}"]`);
-        if (divider) divider.classList.add("active");
+        if (divider) {
+          divider.classList.add("active");
+          divider.setAttribute("aria-pressed", "true");
+        }
       }
     }
   },
@@ -411,5 +422,5 @@ window.addEventListener(
     preview.restore(); // restore parameters
     preview.update(); // update preview
   },
-  false
+  false,
 );

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -218,7 +218,9 @@ const preview = {
     parent.querySelectorAll(`[data-index="${index}"]`).forEach((el) => {
       parent.removeChild(el);
     });
-    // first line has no preceding divider, so fall back to removing divider after line 1
+    // DOM layout: [Line 1] [divider after=1] [Line 2] [divider after=2] [Line 3]
+    // Remove the divider before the deleted line (index-1), except line 1
+    // has no preceding divider, so remove the one after it instead
     const dividerToRemove = index > 1 ? index - 1 : 1;
     const divider = parent.querySelector(`.group-divider[data-divider-after="${dividerToRemove}"]`);
     if (divider) parent.removeChild(divider);

--- a/src/models/RendererModel.php
+++ b/src/models/RendererModel.php
@@ -55,6 +55,9 @@ class RendererModel
     /** @var bool $random True = Sort lines in random order */
     public $random;
 
+    /** @var array<int>|null $groups Group sizes for grouped animation mode, null if disabled */
+    public $groups;
+
     /** @var string $fontCSS CSS required for displaying the selected font */
     public $fontCSS;
 
@@ -109,6 +112,7 @@ class RendererModel
         $this->duration = $this->checkNumberPositive($params["duration"] ?? $this->DEFAULTS["duration"], "duration");
         $this->pause = $this->checkNumberNonNegative($params["pause"] ?? $this->DEFAULTS["pause"], "pause");
         $this->repeat = $this->checkBoolean($params["repeat"] ?? $this->DEFAULTS["repeat"]);
+        $this->groups = $this->checkGroups($params["groups"] ?? null, count($this->lines));
         $this->fontCSS = $this->fetchFontCSS($this->font, $this->weight, $params["lines"]);
         $this->letterSpacing = $this->checkLetterSpacing($params["letterSpacing"] ?? $this->DEFAULTS["letterSpacing"]);
     }
@@ -267,5 +271,34 @@ class RendererModel
 
         // Return the default letter spacing value if the input is invalid
         return $this->DEFAULTS["letterSpacing"];
+    }
+
+    /**
+     * Validate and parse the groups parameter
+     *
+     * @param string|null $groups Comma-separated group sizes, e.g. "2,1"
+     * @param int $lineCount Total number of lines
+     * @return array<int>|null Parsed group sizes, or null if parameter not provided
+     */
+    private function checkGroups($groups, $lineCount)
+    {
+        if ($groups === null || $groups === "") {
+            return null;
+        }
+        $sizes = [];
+        foreach (explode(",", $groups) as $part) {
+            $n = intval(trim($part));
+            if ($n <= 0) {
+                throw new UnprocessableEntityException("Each group size must be a positive number.");
+            }
+            $sizes[] = $n;
+        }
+        $total = array_sum($sizes);
+        if ($total !== $lineCount) {
+            throw new UnprocessableEntityException(
+                "Sum of group sizes ($total) must equal number of lines ($lineCount).",
+            );
+        }
+        return $sizes;
     }
 }

--- a/src/models/RendererModel.php
+++ b/src/models/RendererModel.php
@@ -113,8 +113,32 @@ class RendererModel
         $this->pause = $this->checkNumberNonNegative($params["pause"] ?? $this->DEFAULTS["pause"], "pause");
         $this->repeat = $this->checkBoolean($params["repeat"] ?? $this->DEFAULTS["repeat"]);
         $this->groups = $this->checkGroups($params["groups"] ?? null, count($this->lines));
+        if ($this->random) {
+            $this->shuffleLines();
+        }
         $this->fontCSS = $this->fetchFontCSS($this->font, $this->weight, $params["lines"]);
         $this->letterSpacing = $this->checkLetterSpacing($params["letterSpacing"] ?? $this->DEFAULTS["letterSpacing"]);
+    }
+
+    /**
+     * Shuffle lines, keeping groups together as units when groups are set
+     */
+    private function shuffleLines()
+    {
+        if ($this->groups !== null) {
+            // Shuffle whole groups so lines within each group stay together
+            $chunks = [];
+            $offset = 0;
+            foreach ($this->groups as $size) {
+                $chunks[] = array_slice($this->lines, $offset, $size);
+                $offset += $size;
+            }
+            shuffle($chunks);
+            $this->lines = array_merge(...$chunks);
+            $this->groups = array_map("count", $chunks);
+        } else {
+            shuffle($this->lines);
+        }
     }
 
     /**
@@ -132,9 +156,6 @@ class RendererModel
             $lines = rtrim($lines, $this->separator);
         }
         $exploded = explode($this->separator, $lines);
-        if ($this->random) {
-            shuffle($exploded);
-        }
         // escape special characters to prevent code injection
         return array_map("htmlspecialchars", $exploded);
     }

--- a/src/models/RendererModel.php
+++ b/src/models/RendererModel.php
@@ -317,7 +317,7 @@ class RendererModel
         $total = array_sum($sizes);
         if ($total !== $lineCount) {
             throw new UnprocessableEntityException(
-                "Sum of group sizes ($total) must equal number of lines ($lineCount).",
+                "Sum of group sizes ($total) must equal number of lines ($lineCount)."
             );
         }
         return $sizes;

--- a/src/templates/main.php
+++ b/src/templates/main.php
@@ -8,26 +8,93 @@
     <?= $fontCSS ?>
 
     <?php $lastLineIndex = count($lines) - 1; ?>
+    <?php
+    // Pre-compute per-line group membership when groups param is provided
+    $groupInfo = [];
+    if ($groups !== null) {
+        $lineIdx = 0;
+        foreach ($groups as $gIdx => $gSize) {
+            $groupStartLine = $lineIdx;
+            for ($p = 0; $p < $gSize; $p++) {
+                $groupInfo[$lineIdx] = [
+                    "groupIndex" => $gIdx,
+                    "positionInGroup" => $p,
+                    "groupSize" => $gSize,
+                    "groupStartLine" => $groupStartLine,
+                    "lastLineInGroup" => $groupStartLine + $gSize - 1,
+                    "isFirstGroup" => $gIdx === 0,
+                ];
+                $lineIdx++;
+            }
+        }
+    }
+    ?>
     <?php for ($i = 0; $i <= $lastLineIndex; ++$i): ?>
         <path id='path<?= $i ?>'>
-            <?php if (!$multiline): ?>
+            <?php if ($groups !== null): ?>
+                <!-- Grouped lines: lines within a group type sequentially, all clear together -->
+                <?php
+                $info = $groupInfo[$i];
+                $p = $info["positionInGroup"];
+                $k = $info["groupSize"];
+                $groupStartLine = $info["groupStartLine"];
+                $lastLineInGroup = $info["lastLineInGroup"];
+
+                $lineHeight = $size + 5;
+                $yOffset = ($p + 1) * $lineHeight;
+                $emptyLine = "m0,$yOffset h0";
+                $fullLine = "m0,$yOffset h$width";
+
+                // Total time for this group: each line occupies one $duration slot, plus one $pause at the end
+                $groupDuration = $k * $duration + $pause;
+
+                // keyTimes: wait for turn, type, hold through group pause, clear simultaneously with group
+                $kt1 = ($p * $duration) / $groupDuration;
+                $kt2 = (($p + 0.8) * $duration) / $groupDuration;
+                $kt3 = (($k - 1 + 0.8) * $duration + $pause) / $groupDuration;
+                $keyTimes = ["0", $kt1, $kt2, $kt3, "1"];
+                $values = [$emptyLine, $emptyLine, $fullLine, $fullLine, $emptyLine];
+
+                // All lines in a group share the same begin trigger
+                if ($info["isFirstGroup"]) {
+                    $begin = $repeat ? "0s;d{$lastLineIndex}.end" : "0s";
+                } else {
+                    $prevGroupLastLine = $groupStartLine - 1;
+                    $begin = "d{$prevGroupLastLine}.end";
+                }
+
+                // Keep last group visible when repeat is disabled
+                $freeze = !$repeat && $lastLineInGroup === $lastLineIndex;
+                if ($freeze) {
+                    $values[4] = $fullLine;
+                }
+                ?>
+                <animate id='d<?= $i ?>' attributeName='d'
+                    begin='<?= $begin ?>'
+                    dur='<?= $groupDuration ?>ms'
+                    fill='<?= $freeze ? "freeze" : "remove" ?>'
+                    values='<?= implode(" ; ", $values) ?>'
+                    keyTimes='<?= implode(";", $keyTimes) ?>' />
+            <?php
+                // start after previous line
+                // if this is the first line, start at 0 seconds
+                // and also after the last line if repeat is true
+                // don't delete text after typing the last line if repeat is false
+                // empty line values
+                // keyTimes for the animation
+
+                elseif (!$multiline): ?>
                 <!-- Single line -->
                 <?php
-                // start after previous line
                 $begin = "d" . ($i - 1) . ".end";
                 if ($i == 0) {
-                    // if this is the first line, start at 0 seconds
-                    // and also after the last line if repeat is true
                     $begin = $repeat ? "0s;d$lastLineIndex.end" : "0s";
                 }
-                // don't delete text after typing the last line if repeat is false
                 $freeze = !$repeat && $i == $lastLineIndex;
-                // empty line values
                 $yOffset = $height / 2;
                 $emptyLine = "m0,$yOffset h0";
                 $fullLine = "m0,$yOffset h$width";
                 $values = [$emptyLine, $fullLine, $fullLine, $freeze ? $fullLine : $emptyLine];
-                // keyTimes for the animation
                 $keyTimes = [
                     "0",
                     (0.8 * $duration) / ($duration + $pause),

--- a/src/views/RendererView.php
+++ b/src/views/RendererView.php
@@ -37,6 +37,7 @@ class RendererView
             "width" => $this->model->width,
             "height" => $this->model->height,
             "multiline" => $this->model->multiline,
+            "groups" => $this->model->groups,
             "fontCSS" => $this->model->fontCSS,
             "duration" => $this->model->duration,
             "pause" => $this->model->pause,

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -369,6 +369,59 @@ final class OptionsTest extends TestCase
     }
 
     /**
+     * Test valid groups parameter
+     */
+    public function testValidGroups(): void
+    {
+        $params = [
+            "lines" => "a;b;c",
+            "groups" => "2,1",
+        ];
+        $model = new RendererModel("src/templates/main.php", $params);
+        $this->assertEquals([2, 1], $model->groups);
+    }
+
+    /**
+     * Test groups not provided returns null
+     */
+    public function testGroupsNotProvided(): void
+    {
+        $params = [
+            "lines" => "a;b;c",
+        ];
+        $model = new RendererModel("src/templates/main.php", $params);
+        $this->assertNull($model->groups);
+    }
+
+    /**
+     * Test groups sum mismatch throws exception
+     */
+    public function testGroupsSumMismatch(): void
+    {
+        $this->expectException("InvalidArgumentException");
+        $this->expectExceptionMessage("Sum of group sizes (3) must equal number of lines (2).");
+        $params = [
+            "lines" => "a;b",
+            "groups" => "2,1",
+        ];
+        new RendererModel("src/templates/main.php", $params);
+    }
+
+    /**
+     * Test groups with a zero size throws exception
+     */
+    public function testGroupsZeroSize(): void
+    {
+        $this->expectException("InvalidArgumentException");
+        $this->expectExceptionMessage("Each group size must be a positive number.");
+        $params = [
+            "lines" => "a;b",
+            "groups" => "0,2",
+        ];
+        new RendererModel("src/templates/main.php", $params);
+    }
+
+    /**
      * Test Letter Spacing
      */
     public function testLetterSpacing(): void

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -411,6 +411,28 @@ final class RendererTest extends TestCase
     }
 
     /**
+     * Test random + groups: lines within each group must stay together
+     */
+    public function testRandomWithGroups(): void
+    {
+        $params = [
+            "lines" => "a;b;c;d",
+            "groups" => "2,2",
+            "random" => "true",
+        ];
+        $controller = new RendererController($params);
+        $svg = preg_replace("/\s+/", " ", $controller->render());
+        // All lines should still be present
+        $this->assertStringContainsString("> a </textPath>", $svg);
+        $this->assertStringContainsString("> b </textPath>", $svg);
+        $this->assertStringContainsString("> c </textPath>", $svg);
+        $this->assertStringContainsString("> d </textPath>", $svg);
+        // Lines within each group share the same dur, so groups stay as units
+        // Both groups have size 2 with same timing, verify grouped animation is used
+        $this->assertStringContainsString("Grouped lines", $svg);
+    }
+
+    /**
      * Test Letter Spacing
      */
     public function testLetterSpacing()

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -415,6 +415,8 @@ final class RendererTest extends TestCase
      */
     public function testRandomWithGroups(): void
     {
+        // Seed the RNG so shuffle() is deterministic (this seed reorders the groups to c,d,a,b).
+        mt_srand(2);
         $params = [
             "lines" => "a;b;c;d",
             "groups" => "2,2",
@@ -422,14 +424,21 @@ final class RendererTest extends TestCase
         ];
         $controller = new RendererController($params);
         $svg = preg_replace("/\s+/", " ", $controller->render());
-        // All lines should still be present
-        $this->assertStringContainsString("> a </textPath>", $svg);
-        $this->assertStringContainsString("> b </textPath>", $svg);
-        $this->assertStringContainsString("> c </textPath>", $svg);
-        $this->assertStringContainsString("> d </textPath>", $svg);
-        // Lines within each group share the same dur, so groups stay as units
-        // Both groups have size 2 with same timing, verify grouped animation is used
+
+        // Grouped animation must still be used
         $this->assertStringContainsString("Grouped lines", $svg);
+
+        // Read back the rendered line order
+        preg_match_all("#> ([abcd]) </textPath>#", $svg, $matches);
+        $order = $matches[1];
+        $this->assertEqualsCanonicalizing(["a", "b", "c", "d"], $order, "All lines must survive the shuffle");
+
+        // Groups [a,b] and [c,d] must each stay together in original intra-group order;
+        // shuffling whole groups must never interleave their members.
+        $posA = array_search("a", $order);
+        $posC = array_search("c", $order);
+        $this->assertSame("b", $order[$posA + 1], "Group [a,b] was split apart by the shuffle");
+        $this->assertSame("d", $order[$posC + 1], "Group [c,d] was split apart by the shuffle");
     }
 
     /**

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -68,12 +68,12 @@ final class RendererTest extends TestCase
         $this->assertStringContainsString("keyTimes='0;0;1;1'", $controller->render());
         $this->assertStringContainsString(
             "values='m0,25 h0 ; m0,25 h0 ; m0,25 h380 ; m0,25 h380'",
-            $controller->render()
+            $controller->render(),
         );
         $this->assertStringContainsString("keyTimes='0;0.5;1;1'", $controller->render());
         $this->assertStringContainsString(
             "values='m0,50 h0 ; m0,50 h0 ; m0,50 h380 ; m0,50 h380'",
-            $controller->render()
+            $controller->render(),
         );
     }
 
@@ -108,8 +108,8 @@ final class RendererTest extends TestCase
             1,
             preg_match(
                 "/src: url\(data:font\/truetype;base64,[a-zA-Z0-9\/+=]+\) format\('truetype'\);/",
-                $controller->render()
-            )
+                $controller->render(),
+            ),
         );
         $this->assertStringContainsString("font-family='\"Roboto\", monospace'", $controller->render());
     }
@@ -251,7 +251,7 @@ final class RendererTest extends TestCase
         $this->assertStringContainsString("begin='0s'", $actualSVG);
         $this->assertStringContainsString(
             "begin='d2.end' dur='5000ms' fill='freeze' values='m0,25 h0 ; m0,25 h380 ; m0,25 h380 ; m0,25 h380'",
-            $actualSVG
+            $actualSVG,
         );
         $this->assertStringNotContainsString(";d3.end", $actualSVG);
     }
@@ -325,6 +325,89 @@ final class RendererTest extends TestCase
         foreach ($lines as $line) {
             $this->assertStringContainsString("> $line </textPath>", $actualSVG);
         }
+    }
+
+    /**
+     * Test grouped lines animation: 3 lines with groups=2,1
+     * Group 0 (lines 0,1): both lines type sequentially and clear together.
+     * Group 1 (line 2): behaves like a single-line cycle.
+     */
+    public function testGroupedLinesRender(): void
+    {
+        $params = [
+            "lines" => "line1;line2;line3",
+            "groups" => "2,1",
+            "width" => "400",
+            "height" => "75",
+            "duration" => "5000",
+            "pause" => "0",
+        ];
+        $controller = new RendererController($params);
+        $svg = preg_replace("/\s+/", " ", $controller->render());
+
+        // Group 0, line 0 (p=0, k=2, groupDuration=10000): begins at 0s, types first
+        $this->assertStringContainsString("begin='0s;d2.end'", $svg);
+        $this->assertStringContainsString("dur='10000ms'", $svg);
+        $this->assertStringContainsString("keyTimes='0;0;0.4;0.9;1'", $svg);
+        $this->assertStringContainsString("values='m0,25 h0 ; m0,25 h0 ; m0,25 h400 ; m0,25 h400 ; m0,25 h0'", $svg);
+
+        // Group 0, line 1 (p=1, k=2, groupDuration=10000): same begin, waits for line 0
+        $this->assertStringContainsString("keyTimes='0;0.5;0.9;0.9;1'", $svg);
+        $this->assertStringContainsString("values='m0,50 h0 ; m0,50 h0 ; m0,50 h400 ; m0,50 h400 ; m0,50 h0'", $svg);
+
+        // Group 1, line 2 (k=1, groupDuration=5000): begins after group 0 ends
+        $this->assertStringContainsString("begin='d1.end'", $svg);
+        $this->assertStringContainsString("dur='5000ms'", $svg);
+        $this->assertStringContainsString("keyTimes='0;0;0.8;0.8;1'", $svg);
+        $this->assertStringContainsString("values='m0,25 h0 ; m0,25 h0 ; m0,25 h400 ; m0,25 h400 ; m0,25 h0'", $svg);
+    }
+
+    /**
+     * Test grouped lines with pause: pause applied once per group at the end
+     * groupDuration = k*duration + pause = 2*5000 + 1000 = 11000
+     */
+    public function testGroupedLinesPause(): void
+    {
+        $params = [
+            "lines" => "line1;line2",
+            "groups" => "2",
+            "width" => "400",
+            "height" => "60",
+            "duration" => "5000",
+            "pause" => "1000",
+        ];
+        $controller = new RendererController($params);
+        $svg = preg_replace("/\s+/", " ", $controller->render());
+
+        $this->assertStringContainsString("dur='11000ms'", $svg);
+        // Both lines share the same begin and dur, so both clear at the same moment
+        $this->assertEquals(2, substr_count($svg, "dur='11000ms'"));
+    }
+
+    /**
+     * Test grouped lines with repeat=false: last group stays visible
+     */
+    public function testGroupedLinesRepeatFalse(): void
+    {
+        $params = [
+            "lines" => "line1;line2",
+            "groups" => "1,1",
+            "width" => "400",
+            "height" => "50",
+            "duration" => "5000",
+            "pause" => "0",
+            "repeat" => "false",
+        ];
+        $controller = new RendererController($params);
+        $svg = preg_replace("/\s+/", " ", $controller->render());
+
+        // First group: begin at 0s with no repeat trigger
+        $this->assertStringContainsString("begin='0s'", $svg);
+        $this->assertStringNotContainsString(";d1.end", $svg);
+
+        // Last line should freeze (fill='freeze', last value is fullLine not emptyLine)
+        $this->assertStringContainsString("fill='freeze'", $svg);
+        $this->assertStringContainsString("values='m0,25 h0 ; m0,25 h0 ; m0,25 h400 ; m0,25 h400 ; m0,25 h400'", $svg);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a `groups` parameter that lets users group lines so each group types sequentially, then all lines in the group clear together before the next group starts. For example, `groups=2,1` means the first two lines type and clear as a unit, then the third line plays solo.

### Why this change?

I noticed when setting this up for myself, i had long lines of "Quotes" that didn't work as well for longer lines. If i wanted to split it across two lines, it would also spawn the third line when `multiline` was used.

This change allows you to use both.

The change can be tested here:

[![Typing SVG](https://readme-typing-svgfork-612f33141869.herokuapp.com?font=Source+Code+Pro&weight=900&duration=2000&pause=1000&color=56FEC7&center=true&vCenter=true&width=700&height=100&lines=This+is+in+group+1;This+one+is+in+group+1+as+well;Nothing+is+as+permanent+as+a+temporary+solution+that+works;This+is+in+group+2;This+is+also+in+group+2&groups=2%2C1%2C2)](https://readme-typing-svgfork-612f33141869.herokuapp.com/demo/?font=Source+Code+Pro&weight=900&duration=2000&color=56FEC7&center=true&vCenter=true&width=700&height=100&lines=This+is+in+group+1;This+one+is+in+group+1+as+well;Nothing+is+as+permanent+as+a+temporary+solution+that+works;This+is+in+group+2;This+is+also+in+group+2&groups=2%2C1%2C2)

![readmesvgdemo](https://github.com/user-attachments/assets/7b11c678-d4f0-4675-a340-24e064f1196a)

---

- Backend: new `groups` param on `RendererModel`, validated so group sizes must sum to total line count. `RendererView` and `main.php` template compute per-group SMIL animation timings (staggered `begin`, shared clear points).
- Random + groups: when `random=true` is used with groups, whole groups are shuffled as units so lines within each group stay together.
- Demo UI: interactive clickable dividers between lines. Dividers are invisible by default, appear on hover, and turn blue when active. Groups are computed from active divider positions and serialized to the URL for permalink support.
- Docs: added `groups` to the README options table.

> [!NOTE]
> Some CSS, JS, and PHP files have larger diffs than expected. I ran `composer run format` as described in [CONTRIBUTING.md](https://github.com/DenverCoder1/readme-typing-svg/blob/main/CONTRIBUTING.md) and Prettier decided to reformat a bunch of existing code (wrapping changes, trailing commas, comment repositioning, etc.). I left the reformatting in since fighting the formatter felt worse than including it. Here's what it looks like when you run it:
>
> ```
> src/demo/css/style.css 19ms
> src/demo/css/toggle-dark.css 3ms
> src/demo/js/script.js 54ms
> src/models/RendererModel.php 9ms
> src/templates/main.php 7ms
> tests/RendererTest.php 10ms
> ```
>
> If you'd prefer I separate the formatting into its own commit or revert it entirely, I'm happy to do that. I could not figure out a clean way to get Prettier to only touch the lines I changed. If there's a trick for that, let me know because I genuinely could not find one.

## Type of change

- [ ] Bug fix (added a non-breaking change which fixes an issue)
- [x] New feature (added a non-breaking change which adds functionality)
- [x] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Ran tests with `composer test`
- [x] Added or updated test cases to test new features

Test cases added for grouped lines: `testValidGroups`, `testGroupsNotProvided`, `testGroupsSumMismatch`, `testGroupsZeroSize`, `testGroupedLinesRender`, `testGroupedLinesPause`, `testGroupedLinesRepeatFalse`, `testRandomWithGroups`. All pass (47 total, 1 Google Font test failed due to local networking).
