### PR TITLE
Feat/per line styling

### DIFF
--- a/src/demo/css/style.css
+++ b/src/demo/css/style.css
@@ -137,6 +137,20 @@ h2 {
   grid-template-columns: auto 1fr auto;
 }
 
+.four-columns {
+  grid-template-columns: auto 1fr auto auto;
+}
+
+.line-color {
+  width: 40px;
+  height: 40px;
+  padding: 3px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--card-background);
+  cursor: pointer;
+}
+
 .parameters .btn {
   margin-top: 8px;
 }

--- a/src/demo/index.php
+++ b/src/demo/index.php
@@ -45,7 +45,7 @@
     <div class="container">
         <div class="properties">
             <h2>Add your text</h2>
-            <form class="parameters three-columns lines">
+            <form class="parameters four-columns lines">
                 <!-- Lines are added in JavaScript -->
             </form>
             <button class="add-line btn" onclick="return preview.addLines(1);">+ Add line</button>
@@ -85,9 +85,6 @@
 
                 <label for="pause">Pause (ms after line)</label>
                 <input class="param" type="number" id="pause" name="pause" alt="Pause duration (ms)" placeholder="1000" value="1000">
-
-                <label for="color">Font color</label>
-                <input class="param jscolor jscolor-active" id="color" name="color" alt="Font color" data-jscolor="{ format: 'hexa' }" value="#36BCF7">
 
                 <label for="background">Background color</label>
                 <input class="param jscolor jscolor-active" id="background" name="background" alt="Background color" data-jscolor="{ format: 'hexa' }" value="#00000000">

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -78,6 +78,13 @@ const preview = {
       }
     }
     params.lines = mergeLines(lineInputs, params.separator);
+    // Derive color from per-line inputs: single value if all same, comma-separated if different
+    const lineColorInputs = Array.from(document.querySelectorAll(".line-color"));
+    if (lineColorInputs.length > 0) {
+      const perLineColors = lineColorInputs.map((el) => el.value.replace(/^#/, "").toUpperCase());
+      const firstColor = perLineColors[0];
+      params.color = perLineColors.every((c) => c === firstColor) ? firstColor : perLineColors.join(",");
+    }
     return params;
   },
 
@@ -135,7 +142,7 @@ const preview = {
   addLines(count) {
     for (let i = 0; i < count; i++) {
       const parent = document.querySelector(".lines");
-      const index = parent.querySelectorAll("input").length + 1;
+      const index = parent.querySelectorAll("input.param").length + 1;
       // label
       const label = document.createElement("label");
       label.innerText = `Line ${index}`;
@@ -158,9 +165,18 @@ const preview = {
         '<svg stroke="currentColor" fill="currentColor"  stroke-width="0" viewBox="0 0 1024 1024" height="0.85em" width="0.85em" xmlns="http://www.w3.org/2000/svg"> <path d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"> </path> </svg>';
       deleteButton.dataset.index = index;
 
+      // per-line color input
+      const colorInput = document.createElement("input");
+      colorInput.type = "color";
+      colorInput.className = "line-color";
+      colorInput.dataset.index = index;
+      colorInput.value = "#" + this.defaults.color;
+      colorInput.title = "Line color";
+
       // add elements
       parent.appendChild(label);
       parent.appendChild(input);
+      parent.appendChild(colorInput);
       parent.appendChild(deleteButton);
 
       // disable button if only 1
@@ -203,6 +219,13 @@ const preview = {
         input.setAttribute("name", `line-${inputIndex - 1}`);
       }
     });
+    const colorInputs = parent.querySelectorAll(".line-color");
+    colorInputs.forEach((input) => {
+      const inputIndex = Number(input.dataset.index);
+      if (inputIndex > index) {
+        input.dataset.index = inputIndex - 1;
+      }
+    });
     const buttons = parent.querySelectorAll(".delete-line.btn");
     buttons.forEach((button) => {
       const buttonIndex = Number(button.dataset.index);
@@ -233,6 +256,10 @@ const preview = {
           input.value = value;
         }
       }
+    });
+    // reset per-line colors to default
+    document.querySelectorAll(".line-color").forEach((input) => {
+      input.value = "#" + this.defaults.color;
     });
   },
 
@@ -286,6 +313,15 @@ const preview = {
     this.addLines(lineInputs.length);
     lineInputs.forEach((line, index) => {
       document.querySelector(`#line-${index + 1}`).value = line;
+    });
+    // restore per-line colors from (possibly comma-separated) color param
+    const colorParam = params.color || this.defaults.color;
+    const perLineColors = colorParam.split(",");
+    document.querySelectorAll(".line-color").forEach((input, i) => {
+      const raw = (perLineColors[i] || perLineColors[perLineColors.length - 1]).replace(/^#/, "").substring(0, 6);
+      if (raw.length === 6) {
+        input.value = "#" + raw;
+      }
     });
   },
 };

--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -166,13 +166,14 @@ const preview = {
       deleteButton.dataset.index = index;
 
       // per-line color input
+      // per-line color input
       const colorInput = document.createElement("input");
       colorInput.type = "color";
       colorInput.className = "line-color";
       colorInput.dataset.index = index;
       colorInput.value = "#" + this.defaults.color;
       colorInput.title = "Line color";
-
+      colorInput.setAttribute("aria-label", `Color for line ${index}`);
       // add elements
       parent.appendChild(label);
       parent.appendChild(input);

--- a/src/models/RendererModel.php
+++ b/src/models/RendererModel.php
@@ -61,6 +61,15 @@ class RendererModel
     /** @var string $letterSpacing Letter spacing */
     public $letterSpacing;
 
+    /** @var array<string> $colors Per-line font colors */
+    public $colors;
+
+    /** @var array<int> $sizes Per-line font sizes */
+    public $sizes;
+
+    /** @var array<string> $letterSpacings Per-line letter spacings */
+    public $letterSpacings;
+
     /** @var string $template Path to template file */
     public $template;
 
@@ -111,6 +120,99 @@ class RendererModel
         $this->repeat = $this->checkBoolean($params["repeat"] ?? $this->DEFAULTS["repeat"]);
         $this->fontCSS = $this->fetchFontCSS($this->font, $this->weight, $params["lines"]);
         $this->letterSpacing = $this->checkLetterSpacing($params["letterSpacing"] ?? $this->DEFAULTS["letterSpacing"]);
+        $lineCount = count($this->lines);
+        $this->colors = $this->buildPerLineArray(
+            $params["color"] ?? $this->DEFAULTS["color"],
+            [$this, "parseColor"],
+            $this->color,
+            $lineCount
+        );
+        $this->sizes = $this->buildPerLineArray(
+            $params["size"] ?? $this->DEFAULTS["size"],
+            [$this, "parsePositiveInt"],
+            $this->size,
+            $lineCount
+        );
+        $this->letterSpacings = $this->buildPerLineArray(
+            $params["letterSpacing"] ?? $this->DEFAULTS["letterSpacing"],
+            [$this, "parseLetterSpacing"],
+            $this->letterSpacing,
+            $lineCount
+        );
+        // Keep global properties consistent with the first per-line value so that
+        // layout calculations (e.g. multiline line-height) use a sensible default.
+        $this->color = $this->colors[0];
+        $this->size = $this->sizes[0];
+        $this->letterSpacing = $this->letterSpacings[0];
+    }
+
+    /**
+     * Parse a color string and return sanitized color, or null if invalid
+     *
+     * @param string $color Color parameter
+     * @return string|null Sanitized color with preceding hash, or null if invalid
+     */
+    private function parseColor($color): ?string
+    {
+        $sanitized = (string) preg_replace("/[^0-9A-Fa-f]/", "", $color);
+        if (!in_array(strlen($sanitized), [3, 4, 6, 8])) {
+            return null;
+        }
+        return "#" . $sanitized;
+    }
+
+    /**
+     * Parse a positive integer string and return int, or null if invalid
+     *
+     * @param string $num Number parameter
+     * @return int|null Positive integer, or null if invalid
+     */
+    private function parsePositiveInt($num): ?int
+    {
+        $digits = intval(preg_replace("/[^0-9\-]/", "", $num));
+        return $digits > 0 ? $digits : null;
+    }
+
+    /**
+     * Parse a letter-spacing value and return it, or null if invalid
+     *
+     * @param string $letterSpacing Letter spacing parameter
+     * @return string|null Valid letter spacing, or null if invalid
+     */
+    private function parseLetterSpacing($letterSpacing): ?string
+    {
+        $keywords = "normal|inherit|initial|revert|revert-layer|unset";
+        if (preg_match("/^($keywords)$/", $letterSpacing) || $this->isValidUnit($letterSpacing)) {
+            return $letterSpacing;
+        }
+        return null;
+    }
+
+    /**
+     * Build an array of per-line values from a comma-separated parameter string.
+     * Each value is validated using $parser; invalid values fall back to the previous
+     * valid value (or $globalDefault for the first line).
+     *
+     * @param string $param Raw comma-separated parameter string
+     * @param callable $parser Called with each value; returns valid value or null
+     * @param mixed $globalDefault Fallback value when no valid value has been seen yet
+     * @param int $lineCount Number of lines
+     * @return array
+     */
+    private function buildPerLineArray(string $param, callable $parser, $globalDefault, int $lineCount): array
+    {
+        $parts = array_map("trim", explode(",", $param));
+        $result = [];
+        $lastValid = $globalDefault;
+        for ($i = 0; $i < $lineCount; $i++) {
+            $val = $parts[$i] ?? "";
+            $parsed = $parser($val);
+            if ($parsed !== null) {
+                $lastValid = $parsed;
+            }
+            $result[] = $lastValid;
+        }
+        return $result;
     }
 
     /**

--- a/src/templates/main.php
+++ b/src/templates/main.php
@@ -55,10 +55,10 @@
                     values='<?= implode(" ; ", $values) ?>' keyTimes='<?= implode(";", $keyTimes) ?>' />
             <?php endif; ?>
         </path>
-    <text font-family='"<?= $font ?>", monospace' fill='<?= $color ?>' font-size='<?= $size ?>'
+    <text font-family='"<?= $font ?>", monospace' fill='<?= $colors[$i] ?>' font-size='<?= $sizes[$i] ?>'
         dominant-baseline='<?= $vCenter ? "middle" : "auto" ?>'
         x='<?= $center ? "50%" : "0%" ?>' text-anchor='<?= $center ? "middle" : "start" ?>'
-        letter-spacing='<?= $letterSpacing ?>'>
+        letter-spacing='<?= $letterSpacings[$i] ?>'>
         <textPath xlink:href='#path<?= $i ?>'>
             <?= $lines[$i] . "\n" ?>
         </textPath>

--- a/src/views/RendererView.php
+++ b/src/views/RendererView.php
@@ -42,6 +42,9 @@ class RendererView
             "pause" => $this->model->pause,
             "repeat" => $this->model->repeat,
             "letterSpacing" => $this->model->letterSpacing,
+            "colors" => $this->model->colors,
+            "sizes" => $this->model->sizes,
+            "letterSpacings" => $this->model->letterSpacings,
         ]);
         // render SVG with output buffering
         ob_start();

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -369,6 +369,97 @@ final class OptionsTest extends TestCase
     }
 
     /**
+     * Test per-line colors: single color applies to all lines
+     */
+    public function testPerLineColorsSingle(): void
+    {
+        $params = [
+            "lines" => "Hello;World;Foo",
+            "color" => "FF0000",
+        ];
+        $model = new RendererModel("src/templates/main.php", $params);
+        $this->assertEquals(["#FF0000", "#FF0000", "#FF0000"], $model->colors);
+    }
+
+    /**
+     * Test per-line colors: each line gets its own color
+     */
+    public function testPerLineColorsMultiple(): void
+    {
+        $params = [
+            "lines" => "Hello;World;Foo",
+            "color" => "FF0000,00FF00,0000FF",
+        ];
+        $model = new RendererModel("src/templates/main.php", $params);
+        $this->assertEquals(["#FF0000", "#00FF00", "#0000FF"], $model->colors);
+    }
+
+    /**
+     * Test per-line colors: fewer colors than lines repeats the last valid color
+     */
+    public function testPerLineColorsFallbackToLast(): void
+    {
+        $params = [
+            "lines" => "Hello;World;Foo",
+            "color" => "FF0000,00FF00",
+        ];
+        $model = new RendererModel("src/templates/main.php", $params);
+        $this->assertEquals(["#FF0000", "#00FF00", "#00FF00"], $model->colors);
+    }
+
+    /**
+     * Test per-line colors: invalid color falls back to the previous valid value
+     */
+    public function testPerLineColorsInvalidFallback(): void
+    {
+        $params = [
+            "lines" => "Hello;World;Foo",
+            "color" => "FF0000,invalid,0000FF",
+        ];
+        $model = new RendererModel("src/templates/main.php", $params);
+        $this->assertEquals(["#FF0000", "#FF0000", "#0000FF"], $model->colors);
+    }
+
+    /**
+     * Test per-line sizes: single size applies to all lines
+     */
+    public function testPerLineSizesSingle(): void
+    {
+        $params = [
+            "lines" => "Hello;World",
+            "size" => "24",
+        ];
+        $model = new RendererModel("src/templates/main.php", $params);
+        $this->assertEquals([24, 24], $model->sizes);
+    }
+
+    /**
+     * Test per-line sizes: each line gets its own size
+     */
+    public function testPerLineSizesMultiple(): void
+    {
+        $params = [
+            "lines" => "Hello;World;Foo",
+            "size" => "20,30,14",
+        ];
+        $model = new RendererModel("src/templates/main.php", $params);
+        $this->assertEquals([20, 30, 14], $model->sizes);
+    }
+
+    /**
+     * Test per-line letter spacings: each line gets its own letter spacing
+     */
+    public function testPerLineLetterSpacingsMultiple(): void
+    {
+        $params = [
+            "lines" => "Hello;World",
+            "letterSpacing" => "2px,normal",
+        ];
+        $model = new RendererModel("src/templates/main.php", $params);
+        $this->assertEquals(["2px", "normal"], $model->letterSpacings);
+    }
+
+    /**
      * Test Letter Spacing
      */
     public function testLetterSpacing(): void


### PR DESCRIPTION
Closes #409

## Summary
- Each line can now have its own `color`, `size`, and `letterSpacing`
  via comma-separated values in the existing parameters
- Fewer values than lines → last valid value repeats
- Single value → applies globally (fully backwards compatible)
- Demo UI: each line has its own color picker; global font color removed from Options

## Usage
?lines=Hello;World;Foo&color=FF0000,00FF00,0000FF&size=20,30,14

## Test plan
- [x] All 46 existing tests pass
- [x] New tests: single/multiple colors, fallback, invalid, per-line sizes, letter spacings
- [x] SVG output verified: each <text> gets correct fill and font-size
- [x] Backwards compatible: existing single-value URLs unchanged
