### PR TITLE
fix(demo): escape parentheses in generated markdown/HTML output

### DIFF
--- a/src/demo/js/script.js
+++ b/src/demo/js/script.js
@@ -124,7 +124,13 @@ const preview = {
    * @returns The encoded string
    */
   customEncode(str) {
-    return encodeURIComponent(str).replace(/%3B/g, ";").replace(/%20/g, "+");
+    // encodeURIComponent doesn't escape ( and ), which breaks the generated
+    // markdown link syntax [![...](url)](...) when they appear in the input
+    return encodeURIComponent(str)
+      .replace(/%3B/g, ";")
+      .replace(/%20/g, "+")
+      .replace(/\(/g, "%28")
+      .replace(/\)/g, "%29");
   },
 
   /**


### PR DESCRIPTION
## Summary

Fixes #481.

`customEncode` in `src/demo/js/script.js` uses `encodeURIComponent`, which does not escape `(` and `)`. When a line contains a closing parenthesis (e.g. `hello :)`), the raw `)` ends up in the generated image URL and prematurely closes the markdown link syntax `[![...](url)](...)`, breaking the image/link once pasted into a README.

This change additionally percent-encodes `(` and `)` (`%28` / `%29`) after the existing `encodeURIComponent` call, alongside the existing special-casing of `;` and spaces. The PHP backend already URL-decodes query parameters normally, so this doesn't require any server-side change.

## Type of change

- [x] Bug fix (added a non-breaking change which fixes an issue)
- [ ] New feature (added a non-breaking change which adds functionality)
- [ ] Updated documentation (updated the readme, templates, or other repo files)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] Ran tests with `composer test`
- [ ] Added or updated test cases to test new features

Manually verified with Node that `customEncode("hello :)")` now produces `hello+%3A%29`, and confirmed the resulting markdown renders correctly (image and link intact) using GitHub's markdown render API (`POST /markdown`), where previously the `)` truncated the image URL and broke the link.